### PR TITLE
Don't require ACL tokens to run consul-dataplane

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ RUN go build ./cmd/consul-dataplane
 FROM alpine:3.16 as consul-dataplane-container
 WORKDIR /root/
 RUN apk add gcompat
-COPY --from=consul-dataplane-binary /cdp/consul-dataplane ./
+COPY --from=consul-dataplane-binary /cdp/consul-dataplane /usr/local/bin/consul-dataplane
 COPY --from=envoy-binary /usr/local/bin/envoy /usr/local/bin/envoy
 ENTRYPOINT [ "./consul-dataplane" ]

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"testing"
 
-	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul-dataplane/internal/consul-proto/pbdataplane"
@@ -70,21 +70,6 @@ func TestNewConsulDPError(t *testing.T) {
 			name:      "missing consul server grpc port",
 			modFn:     func(c *Config) { c.Consul.GRPCPort = 0 },
 			expectErr: "consul server gRPC port not specified",
-		},
-		{
-			name:      "missing credentials",
-			modFn:     func(c *Config) { c.Consul.Credentials = nil },
-			expectErr: "consul credentials not specified",
-		},
-		{
-			name:      "missing static credentials",
-			modFn:     func(c *Config) { c.Consul.Credentials.Static = nil },
-			expectErr: "only static credentials are supported but none were specified",
-		},
-		{
-			name:      "missing static credentials token",
-			modFn:     func(c *Config) { c.Consul.Credentials.Static.Token = "" },
-			expectErr: "only static credentials are supported but none were specified",
 		},
 		{
 			name:      "missing service config",


### PR DESCRIPTION
Currently we fail if a static ACL token is not provided, but if Consul server doesn't have ACLs enabled we still want to be able to run consul-dataplane. 

Also, update docker image to copy binary to `/usr/local/bin` and add some additional logging.