### PR TITLE
Add CODEOWNERS file 🔒

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @hashicorp/consul-core
+
+# release configuration
+/.release/                              @hashicorp/release-engineering
+/.github/workflows/build.yml            @hashicorp/release-engineering


### PR DESCRIPTION
Per the CRT onboarding guide, this PR makes @hashicorp/release-engineering the owners of our build and release configuration and @hashicorp/consul-core the owners of everything else.
