### PR TITLE
Implement metrics merging for Envoy and service metrics

### DIFF
--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -53,6 +53,7 @@ var (
 	promKeyFile           string
 	promCertFile          string
 	promServiceMetricsURL string
+	promScrapePath        string
 
 	adminBindAddr    string
 	adminBindPort    int
@@ -106,6 +107,7 @@ func init() {
 	flag.StringVar(&promKeyFile, "telemetry-prom-key-file", "", "The path to the client private key used to serve Prometheus metrics.")
 	flag.StringVar(&promCertFile, "telemetry-prom-cert-file", "", "The path to the client certificate used to serve Prometheus metrics.")
 	flag.StringVar(&promServiceMetricsURL, "telemetry-prom-service-metrics-url", "", "Prometheus metrics at this URL are scraped and included in Consul Dataplane's main Prometheus metrics.")
+	flag.StringVar(&promScrapePath, "telemetry-prom-scrape-path", "", "The URL path where Envoy serves Prometheus metrics.")
 
 	flag.StringVar(&adminBindAddr, "envoy-admin-bind-address", "127.0.0.1", "The address on which the Envoy admin server is available.")
 	flag.IntVar(&adminBindPort, "envoy-admin-bind-port", 19000, "The port on which the Envoy admin server is available.")
@@ -193,6 +195,7 @@ func main() {
 				KeyFile:           promKeyFile,
 				CertFile:          promCertFile,
 				ServiceMetricsURL: promServiceMetricsURL,
+				ScrapePath:        promScrapePath,
 			},
 		},
 		Envoy: &consuldp.EnvoyConfig{

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -48,6 +48,12 @@ var (
 
 	useCentralTelemetryConfig bool
 
+	promRetentionTime     string
+	promCACertsPath       string
+	promKeyFile           string
+	promCertFile          string
+	promServiceMetricsURL string
+
 	adminBindAddr    string
 	adminBindPort    int
 	readyBindAddr    string
@@ -94,6 +100,12 @@ func init() {
 	flag.Var((*FlagMapValue)(&loginMeta), "login-meta", `A set of key/value pairs to attach to the ACL token. Each pair is formatted as "<key>=<value>". This flag may be passed multiple times.`)
 
 	flag.BoolVar(&useCentralTelemetryConfig, "telemetry-use-central-config", true, "Controls whether the proxy applies the central telemetry configuration.")
+
+	flag.StringVar(&promRetentionTime, "telemetry-prom-retention-time", "", "The duration for Prometheus metrics aggregation.")
+	flag.StringVar(&promCACertsPath, "telemetry-prom-ca-certs-path", "", "The path to a file or directory containing CA certificates used to verify the Prometheus server's certificate.")
+	flag.StringVar(&promKeyFile, "telemetry-prom-key-file", "", "The path to the client private key used to serve Prometheus metrics.")
+	flag.StringVar(&promCertFile, "telemetry-prom-cert-file", "", "The path to the client certificate used to serve Prometheus metrics.")
+	flag.StringVar(&promServiceMetricsURL, "telemetry-prom-service-metrics-url", "", "Prometheus metrics at this URL are scraped and included in Consul Dataplane's main Prometheus metrics.")
 
 	flag.StringVar(&adminBindAddr, "envoy-admin-bind-address", "127.0.0.1", "The address on which the Envoy admin server is available.")
 	flag.IntVar(&adminBindPort, "envoy-admin-bind-port", 19000, "The port on which the Envoy admin server is available.")
@@ -175,6 +187,13 @@ func main() {
 		},
 		Telemetry: &consuldp.TelemetryConfig{
 			UseCentralConfig: useCentralTelemetryConfig,
+			Prometheus: consuldp.PrometheusTelemetryConfig{
+				RetentionTime:     promRetentionTime,
+				CACertsPath:       promCACertsPath,
+				KeyFile:           promKeyFile,
+				CertFile:          promCertFile,
+				ServiceMetricsURL: promServiceMetricsURL,
+			},
 		},
 		Envoy: &consuldp.EnvoyConfig{
 			AdminBindAddress: adminBindAddr,

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -24,7 +24,7 @@ const (
 )
 
 // bootstrapConfig generates the Envoy bootstrap config in JSON format.
-func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) ([]byte, error) {
+func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.BootstrapConfig, []byte, error) {
 	svc := cdp.cfg.Service
 	envoy := cdp.cfg.Envoy
 
@@ -46,9 +46,10 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) ([]byte, error)
 
 	rsp, err := cdp.dpServiceClient.GetEnvoyBootstrapParams(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get envoy bootstrap params: %w", err)
+		return nil, nil, fmt.Errorf("failed to get envoy bootstrap params: %w", err)
 	}
 
+	prom := cdp.cfg.Telemetry.Prometheus
 	args := &bootstrap.BootstrapTplArgs{
 		GRPC: bootstrap.GRPC{
 			AgentAddress: cdp.cfg.XDSServer.BindAddress,
@@ -66,6 +67,8 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) ([]byte, error)
 		Namespace:             rsp.Namespace,
 		Partition:             rsp.Partition,
 		Datacenter:            rsp.Datacenter,
+		PrometheusCertFile:    prom.CertFile,
+		PrometheusKeyFile:     prom.KeyFile,
 	}
 
 	if cdp.xdsServer.listenerNetwork == "unix" {
@@ -76,6 +79,18 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) ([]byte, error)
 		args.GRPC.AgentPort = xdsServerFullAddr[1]
 	}
 
+	if path := prom.CACertsPath; path != "" {
+		fi, err := os.Stat(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		if fi.IsDir() {
+			args.PrometheusCAPath = path
+		} else {
+			args.PrometheusCAFile = path
+		}
+	}
+
 	var bootstrapConfig bootstrap.BootstrapConfig
 	if envoy.ReadyBindAddress != "" && envoy.ReadyBindPort != 0 {
 		bootstrapConfig.ReadyBindAddr = net.JoinHostPort(envoy.ReadyBindAddress, strconv.Itoa(envoy.ReadyBindPort))
@@ -83,11 +98,20 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) ([]byte, error)
 
 	if cdp.cfg.Telemetry.UseCentralConfig {
 		if err := mapstructure.WeakDecode(rsp.Config.AsMap(), &bootstrapConfig); err != nil {
-			return nil, fmt.Errorf("failed parsing Proxy.Config: %w", err)
+			return nil, nil, fmt.Errorf("failed parsing Proxy.Config: %w", err)
 		}
+
+		// Envoy is configured with a listener that proxies metrics from its
+		// own admin endpoint (localhost:19000/stats/prometheus). When central
+		// config is enabled, we set the PrometheusBackendPort to instead have
+		// Envoy proxy metrics from Consul Dataplane which serves merged
+		// metrics (Envoy + Dataplane + service metrics).
+		args.PrometheusBackendPort = "20100"
+		// args.PrometheusScrapePath = ...
 	}
 
 	// Note: we pass true for omitDeprecatedTags here - consul-dataplane is clean
 	// slate and we don't need to maintain this legacy behavior.
-	return bootstrapConfig.GenerateJSON(args, true)
+	cfg, err := bootstrapConfig.GenerateJSON(args, true)
+	return &bootstrapConfig, cfg, err
 }

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -69,6 +69,7 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 		Datacenter:            rsp.Datacenter,
 		PrometheusCertFile:    prom.CertFile,
 		PrometheusKeyFile:     prom.KeyFile,
+		PrometheusScrapePath:  prom.ScrapePath,
 	}
 
 	if cdp.xdsServer.listenerNetwork == "unix" {
@@ -106,8 +107,7 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 		// config is enabled, we set the PrometheusBackendPort to instead have
 		// Envoy proxy metrics from Consul Dataplane which serves merged
 		// metrics (Envoy + Dataplane + service metrics).
-		args.PrometheusBackendPort = "20100"
-		// args.PrometheusScrapePath = ...
+		args.PrometheusBackendPort = metricsBackendBindPort
 	}
 
 	// Note: we pass true for omitDeprecatedTags here - consul-dataplane is clean

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -155,7 +155,7 @@ func TestBootstrapConfig(t *testing.T) {
 				dp.xdsServer = &xdsServer{listenerAddress: fmt.Sprintf("127.0.0.1:%d", xdsBindPort)}
 			}
 
-			bsCfg, err := dp.bootstrapConfig(ctx)
+			_, bsCfg, err := dp.bootstrapConfig(ctx)
 			require.NoError(t, err)
 
 			golden(t, bsCfg)

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -85,6 +85,32 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 			},
 		},
+		"custom-prometheus-scrape-path": {
+			&Config{
+				Service: &ServiceConfig{
+					ServiceID: "web-proxy",
+					NodeName:  nodeName,
+				},
+				Envoy: &EnvoyConfig{
+					AdminBindAddress: "127.0.0.1",
+					AdminBindPort:    19000,
+				},
+				Telemetry: &TelemetryConfig{
+					UseCentralConfig: true,
+					Prometheus: PrometheusTelemetryConfig{
+						ScrapePath: "/custom/scrape/path",
+					},
+				},
+				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
+			},
+			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+				Service:  "web",
+				NodeName: nodeName,
+				Config: makeStruct(map[string]any{
+					"envoy_prometheus_bind_addr": "0.0.0.0:20200",
+				}),
+			},
+		},
 		"ready-listener": {
 			&Config{
 				Service: &ServiceConfig{

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -244,6 +244,8 @@ type PrometheusTelemetryConfig struct {
 	// The metrics at this URL are scraped and merged into Consul Dataplane's
 	// main Prometheus metrics.
 	ServiceMetricsURL string
+	// ScrapePath is the URL path where Envoy serves Prometheus metrics.
+	ScrapePath string
 }
 
 // EnvoyConfig contains configuration for the Envoy process.

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -220,8 +220,30 @@ type TelemetryConfig struct {
 	// UseCentralConfig controls whether the proxy will apply the central telemetry
 	// configuration.
 	UseCentralConfig bool
+	// Prometheus contains Prometheus-specific configuration that cannot be
+	// determined from central telemetry configuration.
+	Prometheus PrometheusTelemetryConfig
+}
 
-	// TODO(NET-100): Local telemetry configuration.
+// PrometheusTelemetryConfig contains Prometheus-specific telemetry config.
+type PrometheusTelemetryConfig struct {
+	// RetentionTime controls the duration that metrics are aggregated for.
+	RetentionTime string
+	// CACertsPath is a path to a file or directory containing CA certificates
+	// to use to verify the Prometheus server's certificate. This is only
+	// necessary if the server presents a certificate that isn't signed by a
+	// trusted public CA.
+	CACertsPath string
+	// KeyFile is a path to the client private key used for serving Prometheus
+	// metrics.
+	KeyFile string
+	// CertFile is a path to the client certificate used for serving Prometheus
+	// metrics.
+	CertFile string
+	// ServiceMetricsURL is an optional URL that must serve Prometheus metrics.
+	// The metrics at this URL are scraped and merged into Consul Dataplane's
+	// main Prometheus metrics.
+	ServiceMetricsURL string
 }
 
 // EnvoyConfig contains configuration for the Envoy process.

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -91,7 +91,6 @@ func validateConfig(cfg *Config) error {
 		return errors.New("envoy xDS bind address not specified")
 	case !strings.HasPrefix(cfg.XDSServer.BindAddress, "unix://") && !net.ParseIP(cfg.XDSServer.BindAddress).IsLoopback():
 		return errors.New("non-local xDS bind address not allowed")
-
 	}
 
 	creds := cfg.Consul.Credentials

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -32,6 +32,16 @@ func validConfig() *Config {
 		XDSServer: &XDSServer{
 			BindAddress: "127.0.0.1",
 		},
+		Telemetry: &TelemetryConfig{
+			UseCentralConfig: true,
+			Prometheus: PrometheusTelemetryConfig{
+				RetentionTime:     "30s",
+				CACertsPath:       "/tmp/my-certs/",
+				KeyFile:           "/tmp/my-key.pem",
+				CertFile:          "/tmp/my-cert.pem",
+				ServiceMetricsURL: "http://127.0.0.1:12345/metrics",
+			},
+		},
 	}
 }
 
@@ -114,6 +124,21 @@ func TestNewConsulDPError(t *testing.T) {
 			name:      "missing logging config",
 			modFn:     func(c *Config) { c.Logging = nil },
 			expectErr: "logging settings not specified",
+		},
+		{
+			name:      "missing prometheus ca certs path",
+			modFn:     func(c *Config) { c.Telemetry.Prometheus.CACertsPath = "" },
+			expectErr: "Must provide -telemetry-prom-ca-certs-path, -telemetry-prom-cert-file, and -telemetry-prom-key-file to enable TLS for prometheus metrics",
+		},
+		{
+			name:      "missing prometheus key file",
+			modFn:     func(c *Config) { c.Telemetry.Prometheus.KeyFile = "" },
+			expectErr: "Must provide -telemetry-prom-ca-certs-path, -telemetry-prom-cert-file, and -telemetry-prom-key-file to enable TLS for prometheus metrics",
+		},
+		{
+			name:      "missing prometheus cert file",
+			modFn:     func(c *Config) { c.Telemetry.Prometheus.CertFile = "" },
+			expectErr: "Must provide -telemetry-prom-ca-certs-path, -telemetry-prom-cert-file, and -telemetry-prom-key-file to enable TLS for prometheus metrics",
 		},
 		{
 			name:      "missing xds bind address",

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	envoyMetricsUrl = "http://127.0.0.1:19000/stats/prometheus"
-	metricsBindAddr = "127.0.0.1:20100"
+	envoyMetricsUrl        = "http://127.0.0.1:19000/stats/prometheus"
+	metricsBackendBindPort = "20100"
+	metricsBackendBindAddr = "127.0.0.1:" + metricsBackendBindPort
 )
 
 func (cdp *ConsulDataplane) setupMetricsServer() {
@@ -17,7 +18,7 @@ func (cdp *ConsulDataplane) setupMetricsServer() {
 	mux.HandleFunc("/stats/prometheus", cdp.mergedMetricsHandler)
 	cdp.metricsServer = &metricsServer{
 		httpServer: &http.Server{
-			Addr:    metricsBindAddr,
+			Addr:    metricsBackendBindAddr,
 			Handler: mux,
 		},
 		client: &http.Client{

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -1,0 +1,95 @@
+package consuldp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	envoyMetricsUrl = "http://127.0.0.1:19000/stats/prometheus"
+	metricsBindAddr = "127.0.0.1:20100"
+)
+
+func (cdp *ConsulDataplane) setupMetricsServer() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/stats/prometheus", cdp.mergedMetricsHandler)
+	cdp.metricsServer = &metricsServer{
+		httpServer: &http.Server{
+			Addr:    metricsBindAddr,
+			Handler: mux,
+		},
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		exitedCh: make(chan struct{}),
+	}
+}
+
+func (cdp *ConsulDataplane) startMetricsServer() {
+	cdp.logger.Info("starting metrics server", "address", cdp.metricsServer.httpServer.Addr)
+	defer close(cdp.metricsServer.exitedCh)
+	err := cdp.metricsServer.httpServer.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		cdp.logger.Error("failed to serve metrics requests", "error", err)
+	}
+}
+
+func (cdp *ConsulDataplane) stopMetricsServer() {
+	if cdp.metricsServer != nil && cdp.metricsServer.httpServer != nil {
+		cdp.logger.Debug("stopping metrics server")
+		err := cdp.metricsServer.httpServer.Close()
+		if err != nil {
+			cdp.logger.Warn("error while closing metrics server", "error", err)
+		}
+	}
+}
+
+func (cdp *ConsulDataplane) metricsServerExited() <-chan struct{} {
+	return cdp.metricsServer.exitedCh
+}
+
+// mergedMetricsHandler responds with merged metrics from multiple sources:
+// Consul Dataplane, Envoy and (optionally) the service/application. The Envoy
+// and service metrics are scraped synchronously during the handling of this
+// request.
+func (cdp *ConsulDataplane) mergedMetricsHandler(rw http.ResponseWriter, _ *http.Request) {
+	cdp.logger.Debug("scraping Envoy metrics", "url", envoyMetricsUrl)
+	if err := cdp.scrapeMetrics(rw, envoyMetricsUrl); err != nil {
+		cdp.scrapeError(rw, envoyMetricsUrl, err)
+		return
+	}
+	telem := cdp.cfg.Telemetry
+	if telem == nil || telem.Prometheus.ServiceMetricsURL == "" {
+		return
+	}
+	url := telem.Prometheus.ServiceMetricsURL
+	cdp.logger.Debug("scraping service metrics", "url", url)
+	if err := cdp.scrapeMetrics(rw, url); err != nil {
+		cdp.scrapeError(rw, url, err)
+		return
+	}
+}
+
+// scrapeMetrics fetches metrics from the given url and copies them to the response.
+func (cdp *ConsulDataplane) scrapeMetrics(rw http.ResponseWriter, url string) error {
+	resp, err := cdp.metricsServer.client.Get(url)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("status code %d", resp.StatusCode)
+	}
+	// metrics are are in a text format with one per line.
+	// so, when merging metrics we simply write all lines
+	_, err = io.Copy(rw, resp.Body)
+	return err
+}
+
+// scrapeError logs an error and responds to the http request with an error.
+func (cdp *ConsulDataplane) scrapeError(rw http.ResponseWriter, url string, err error) {
+	cdp.logger.Error("failed to scrape metrics", "url", url, "error", err)
+	msg := fmt.Sprintf("failed to scrape metrics at url %q", url)
+	http.Error(rw, msg, http.StatusInternalServerError)
+}

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -1,0 +1,116 @@
+package consuldp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsServer(t *testing.T) {
+	cases := map[string]struct {
+		telemetry  *TelemetryConfig
+		expMetrics []string
+	}{
+		"no service metrics": {
+			telemetry: &TelemetryConfig{UseCentralConfig: true},
+			expMetrics: []string{
+				makeFakeMetric(envoyMetricsUrl),
+			},
+		},
+		"with service metrics": {
+			telemetry: &TelemetryConfig{
+				UseCentralConfig: true,
+				Prometheus: PrometheusTelemetryConfig{
+					ServiceMetricsURL: "fake-service-metrics-url",
+				},
+			},
+			expMetrics: []string{
+				makeFakeMetric(envoyMetricsUrl),
+				makeFakeMetric("fake-service-metrics-url"),
+			},
+		},
+	}
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			cdp := &ConsulDataplane{
+				cfg:    &Config{Telemetry: c.telemetry},
+				logger: hclog.NewNullLogger(),
+			}
+			cdp.setupMetricsServer()
+
+			m := cdp.metricsServer
+			require.NotNil(t, m)
+			require.NotNil(t, m.httpServer)
+			require.NotNil(t, m.client)
+			require.NotNil(t, m.exitedCh)
+			require.Equal(t, metricsBindAddr, m.httpServer.Addr)
+			require.IsType(t, &http.Client{}, m.client)
+			require.Greater(t, m.client.(*http.Client).Timeout, time.Duration(0))
+
+			// Mock get requests to Envoy and Service instance metrics
+			// so that they return a fake metric string.
+			m.client = &mockClient{}
+
+			// Have consul-dataplane's metrics server start on an open port.
+			// And figure out what port was used so we can make requests to it.
+			// Conveniently, this seems to wait until the server is ready for requests.
+			portCh := make(chan int, 1)
+			m.httpServer.Addr = "127.0.0.1:0"
+			m.httpServer.BaseContext = func(l net.Listener) context.Context {
+				port := l.Addr().(*net.TCPAddr).Port
+				defer close(portCh)
+				portCh <- port
+				return context.Background()
+			}
+
+			go cdp.startMetricsServer()
+			t.Cleanup(cdp.stopMetricsServer)
+
+			var port int
+			select {
+			case port = <-portCh:
+			case <-time.After(5 * time.Second):
+			}
+
+			require.NotEqual(t, port, 0, "test failed to figure out metrics server port")
+			log.Printf("port = %v", port)
+
+			url := fmt.Sprintf("http://127.0.0.1:%d/stats/prometheus", port)
+			resp, err := http.Get(url)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			expMetrics := strings.Join(c.expMetrics, "")
+			require.Equal(t, expMetrics, string(body))
+
+		})
+	}
+
+}
+
+type mockClient struct{}
+
+func (c *mockClient) Get(url string) (*http.Response, error) {
+	buf := bytes.NewBufferString(makeFakeMetric(url))
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(buf),
+	}, nil
+}
+
+func makeFakeMetric(url string) string {
+	return fmt.Sprintf(`fake_metric{url="%s"} 1\n`, url)
+}

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -83,9 +83,7 @@ func TestMetricsServerEnabled(t *testing.T) {
 			portCh := make(chan int, 1)
 			m.httpServer.Addr = "127.0.0.1:0"
 			m.httpServer.BaseContext = func(l net.Listener) context.Context {
-				port := l.Addr().(*net.TCPAddr).Port
-				defer close(portCh)
-				portCh <- port
+				portCh <- l.Addr().(*net.TCPAddr).Port
 				return context.Background()
 			}
 

--- a/pkg/consuldp/mock_dataplane_service_client.go
+++ b/pkg/consuldp/mock_dataplane_service_client.go
@@ -61,9 +61,9 @@ type MockDataplaneServiceClient_GetEnvoyBootstrapParams_Call struct {
 }
 
 // GetEnvoyBootstrapParams is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *pbdataplane.GetEnvoyBootstrapParamsRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *pbdataplane.GetEnvoyBootstrapParamsRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataplaneServiceClient_Expecter) GetEnvoyBootstrapParams(ctx interface{}, in interface{}, opts ...interface{}) *MockDataplaneServiceClient_GetEnvoyBootstrapParams_Call {
 	return &MockDataplaneServiceClient_GetEnvoyBootstrapParams_Call{Call: _e.mock.On("GetEnvoyBootstrapParams",
 		append([]interface{}{ctx, in}, opts...)...)}
@@ -123,9 +123,9 @@ type MockDataplaneServiceClient_GetSupportedDataplaneFeatures_Call struct {
 }
 
 // GetSupportedDataplaneFeatures is a helper method to define mock.On call
-//  - ctx context.Context
-//  - in *pbdataplane.GetSupportedDataplaneFeaturesRequest
-//  - opts ...grpc.CallOption
+//   - ctx context.Context
+//   - in *pbdataplane.GetSupportedDataplaneFeaturesRequest
+//   - opts ...grpc.CallOption
 func (_e *MockDataplaneServiceClient_Expecter) GetSupportedDataplaneFeatures(ctx interface{}, in interface{}, opts ...interface{}) *MockDataplaneServiceClient_GetSupportedDataplaneFeatures_Call {
 	return &MockDataplaneServiceClient_GetSupportedDataplaneFeatures_Call{Call: _e.mock.On("GetSupportedDataplaneFeatures",
 		append([]interface{}{ctx, in}, opts...)...)}

--- a/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
@@ -1,0 +1,259 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "web",
+    "id": "web-proxy",
+    "metadata": {
+      "node_name": "agentless-node",
+      "namespace": "default",
+      "partition": "default"
+    }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576
+        }
+      }
+    ]
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "consul-dataplane",
+        "ignore_health_on_host_removal": false,
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "loadAssignment": {
+          "clusterName": "consul-dataplane",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 1234
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "name": "prometheus_backend",
+        "ignore_health_on_host_removal": false,
+        "connect_timeout": "5s",
+        "type": "STATIC",
+        "http_protocol_options": {},
+        "loadAssignment": {
+          "clusterName": "prometheus_backend",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 20100
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "listeners": [
+      {
+        "name": "envoy_prometheus_metrics_listener",
+        "address": {
+          "socket_address": {
+            "address": "0.0.0.0",
+            "port_value": 20200
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "stat_prefix": "envoy_prometheus_metrics",
+                  "codec_type": "HTTP1",
+                  "route_config": {
+                    "name": "self_admin_route",
+                    "virtual_hosts": [
+                      {
+                        "name": "self_admin",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "path": "/custom/scrape/path"
+                            },
+                            "route": {
+                              "cluster": "prometheus_backend",
+                              "prefix_rewrite": "/stats/prometheus"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "direct_response": {
+                              "status": 404
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+    "stats_tags": [
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:([^.]+)\\.)?[^.]+\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.partition"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.([^.]+\\.(?:[^.]+\\.)?([^.]+)\\.external\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.peer"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.(([^.]+)(?:\\.[^.]+)?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream_peered\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.peer"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.([^.]+(?:\\.([^.]+))?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.partition"
+      },
+      {
+        "tag_name": "local_cluster",
+        "fixed_value": "web"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "web"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
+        "fixed_value": "default"
+      }
+    ],
+    "use_all_default_tags": true
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "transport_api_version": "V3",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": ""
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "consul-dataplane"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This implements a metrics server that serves merged Prometheus metrics for both Envoy and (optionally) service metrics, similar to [consul-k8s](https://www.consul.io/docs/k8s/connect/observability/metrics).

This does not implement the new metrics for Consul Dataplane itself (will come in a subsequent PR)

* If `-telemetry-use-central-config` is passed and if a Prometheus bind address is present in `GetEnvoyBootstrapParams` response, then metrics merging is enabled:
  * Envoy's Prometheus listener is configured to proxy to Consul Dataplane, so that merged metrics are served from Consul Dataplane out through Envoy
  * Consul Dataplane starts a metrics server that serves merged metrics at `127.0.0.1:20100/stats/prometheus`
  * When Consul Dataplane's metrics server receives a request, it scrapes metrics from Envoy's admin interface and (optionally) from the url specified by `-telemetry-prom-service-metrics-url`.
* Add the following flags per the RFC
  * `-telemetry-prom-retention-time` (unused in this PR)
  * `-telemetry-prom-ca-certs-path`
  * `-telemetry-prom-key-file`
  * `-telemetry-prom-cert-file`
  * `-telemetry-prom-service-metrics-url`
  * `-telemetry-prom-scrape-path`

