### PR TITLE
DNS transparent proxy

### DIFF
--- a/.changelog/22.txt
+++ b/.changelog/22.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+dns: support for dns proxying to consul for both tcp and udp
+```

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -116,7 +116,7 @@ func init() {
 	flag.BoolVar(&tlsInsecureSkipVerify, "tls-insecure-skip-verify", false, "Do not verify the server's certificate. Useful for testing, but not recommended for production.")
 
 	flag.StringVar(&consulDNSBindAddr, "consul-dns-bind-addr", "127.0.0.1", "The address that will be bound to the consul dns proxy.")
-	flag.IntVar(&consulDNSPort, "consul-dns-port", -1, "The port the consul dns proxy will listen on. By default 0 disables the dns proxy")
+	flag.IntVar(&consulDNSPort, "consul-dns-bind-port", -1, "The port the consul dns proxy will listen on. By default -1 disables the dns proxy")
 
 }
 
@@ -218,6 +218,7 @@ func main() {
 
 	err = consuldpInstance.Run(ctx)
 	if err != nil {
+		cancel()
 		log.Fatal(err)
 	}
 }

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -56,6 +56,9 @@ var (
 
 	xdsBindAddr string
 	xdsBindPort int
+
+	consulDNSBindAddr string
+	consulDNSPort     int
 )
 
 func init() {
@@ -110,6 +113,10 @@ func init() {
 	flag.StringVar(&tlsKeyFile, "tls-key", "", "The path to a client private key file (only required if tls.grpc.verify_incoming is enabled on the server).")
 	flag.StringVar(&tlsServerName, "tls-server-name", "", "The hostname to expect in the server certificate's subject (required if -addresses isn't a DNS name).")
 	flag.BoolVar(&tlsInsecureSkipVerify, "tls-insecure-skip-verify", false, "Do not verify the server's certificate. Useful for testing, but not recommended for production.")
+
+	flag.StringVar(&consulDNSBindAddr, "consul-dns-bind-addr", "127.0.0.1", "The address that will be bound to the consul dns proxy.")
+	flag.IntVar(&consulDNSPort, "consul-dns-port", -1, "The port the consul dns proxy will listen on. By default 0 disables the dns proxy")
+
 }
 
 // validateFlags performs semantic validation of the flag values
@@ -187,6 +194,10 @@ func main() {
 		XDSServer: &consuldp.XDSServer{
 			BindAddress: xdsBindAddr,
 			BindPort:    xdsBindPort,
+		},
+		DNSServer: &consuldp.DNSServerConfig{
+			BindAddr: consulDNSBindAddr,
+			Port:     consulDNSPort,
 		},
 	}
 	consuldpInstance, err := consuldp.NewConsulDP(consuldpCfg)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9
-	github.com/hashicorp/consul/proto-public v0.1.1-0.20220930052510-f22c79f5c226
+	github.com/hashicorp/consul/proto-public v0.1.1-0.20221003150248-ad7295e5d9d4
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9
-	github.com/hashicorp/consul/proto-public v0.1.1-0.20221003150248-ad7295e5d9d4
+	github.com/hashicorp/consul/proto-public v0.1.1
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9
-	github.com/hashicorp/consul/proto-public v0.1.0
+	github.com/hashicorp/consul/proto-public v0.1.1-0.20220930052510-f22c79f5c226
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/mitchellh/mapstructure v1.5.0
@@ -21,9 +21,12 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
@@ -31,5 +34,6 @@ require (
 	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9 h1:1e2vy4aPfxun9DG808QjXtShksPoaQsHvyxhVOyjeRI=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
-github.com/hashicorp/consul/proto-public v0.1.1-0.20220930052510-f22c79f5c226 h1:mzV4riR2dhOou4w2B7rIOB1UgHNuq1vQFrQnl0+x534=
-github.com/hashicorp/consul/proto-public v0.1.1-0.20220930052510-f22c79f5c226/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
+github.com/hashicorp/consul/proto-public v0.1.1-0.20221003150248-ad7295e5d9d4 h1:2muDcPNNFdob75hR7OPb+nL3Ixxk8OItg9giUZvyRiY=
+github.com/hashicorp/consul/proto-public v0.1.1-0.20221003150248-ad7295e5d9d4/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-hclog v1.2.2 h1:ihRI7YFwcZdiSD7SIenIhHfQH3OuDvWerAUBZbeQS3M=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9 h1:1e2vy4aPfxun9DG808QjXtShksPoaQsHvyxhVOyjeRI=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
-github.com/hashicorp/consul/proto-public v0.1.1-0.20221003150248-ad7295e5d9d4 h1:2muDcPNNFdob75hR7OPb+nL3Ixxk8OItg9giUZvyRiY=
-github.com/hashicorp/consul/proto-public v0.1.1-0.20221003150248-ad7295e5d9d4/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
+github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=
+github.com/hashicorp/consul/proto-public v0.1.1/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-hclog v1.2.2 h1:ihRI7YFwcZdiSD7SIenIhHfQH3OuDvWerAUBZbeQS3M=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9 h1:1e2vy4aPfxun9DG808QjXtShksPoaQsHvyxhVOyjeRI=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
-github.com/hashicorp/consul/proto-public v0.1.0 h1:O0LSmCqydZi363hsqc6n2v5sMz3usQMXZF6ziK3SzXU=
-github.com/hashicorp/consul/proto-public v0.1.0/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
+github.com/hashicorp/consul/proto-public v0.1.1-0.20220930052510-f22c79f5c226 h1:mzV4riR2dhOou4w2B7rIOB1UgHNuq1vQFrQnl0+x534=
+github.com/hashicorp/consul/proto-public v0.1.1-0.20220930052510-f22c79f5c226/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-hclog v1.2.2 h1:ihRI7YFwcZdiSD7SIenIhHfQH3OuDvWerAUBZbeQS3M=
@@ -67,8 +67,12 @@ github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46 h1:BysEAd6g+
 github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46/go.mod h1:TjKbv4FhIra0YJ82mws5+4QXOhzv09eAWs4jtOBI4IU=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
-github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
+github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -79,7 +83,10 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -201,8 +208,9 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -28,6 +28,14 @@ type ConsulConfig struct {
 	TLS *TLSConfig
 }
 
+// DNSServerConfig is the configuration for the transparent DNS proxy that will forward requests to consul
+type DNSServerConfig struct {
+	// BindAddr is the address the DNS server will bind to. Default will be 127.0.0.1
+	BindAddr string
+	// Port is the port which the DNS server will bind to.
+	Port int
+}
+
 // TLSConfig contains the TLS settings for communicating with Consul servers.
 type TLSConfig struct {
 	// Disabled causes consul-dataplane to communicate with Consul servers over
@@ -251,6 +259,7 @@ type XDSServer struct {
 // Config is the configuration used by consul-dataplane, consolidated
 // from various sources - CLI flags, env vars, config file settings.
 type Config struct {
+	DNSServer *DNSServerConfig
 	Consul    *ConsulConfig
 	Service   *ServiceConfig
 	Logging   *LoggingConfig

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -81,7 +81,7 @@ func validateConfig(cfg *Config) error {
 		return errors.New("envoy xDS bind address not specified")
 	case !strings.HasPrefix(cfg.XDSServer.BindAddress, "unix://") && !net.ParseIP(cfg.XDSServer.BindAddress).IsLoopback():
 		return errors.New("non-local xDS bind address not allowed")
-	case !strings.HasPrefix(cfg.DNSServer.BindAddr, "unix://") && !net.ParseIP(cfg.DNSServer.BindAddr).IsLoopback():
+	case cfg.DNSServer.Port != -1 && !net.ParseIP(cfg.DNSServer.BindAddr).IsLoopback():
 		return errors.New("non-local DNS proxy bind address not allowed")
 	}
 

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -161,11 +161,6 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to run proxy: %w", err)
 	}
 
-	if err = cdp.startDNSProxy(ctx); err != nil {
-		cdp.logger.Error("failed to start the dns proxy", "error", err)
-		return err
-	}
-
 	doneCh := make(chan error)
 	go func() {
 		select {

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
+	"github.com/hashicorp/consul/proto-public/pbdns"
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc"
 
+	"github.com/hashicorp/consul-dataplane/pkg/dns"
 	"github.com/hashicorp/consul-dataplane/pkg/envoy"
 )
 
@@ -157,6 +159,24 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to run proxy: %w", err)
 	}
 
+	dnsClientInterface := pbdns.NewDNSServiceClient(cdp.serverConn)
+
+	dnsServer, err := dns.NewDNSServer(dns.DNSServerParams{
+		BindAddr: cdp.cfg.DNSServer.BindAddr,
+		Port:     cdp.cfg.DNSServer.Port,
+		Client:   dnsClientInterface,
+		Logger:   cdp.logger,
+	})
+	if err != nil {
+		cdp.logger.Error("failed to create the dns proxy", "error", err)
+		return fmt.Errorf("failed to create dns server: %w", err)
+	}
+	if err = dnsServer.Run(); err != nil {
+		cdp.logger.Error("failed to run the dns proxy", "error", err)
+		return fmt.Errorf("failed to run the dns proxy: %w", err)
+
+	}
+
 	doneCh := make(chan error)
 	go func() {
 		select {
@@ -164,6 +184,7 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 			if err := proxy.Stop(); err != nil {
 				cdp.logger.Error("failed to stop proxy", "error", err)
 			}
+			dnsServer.Stop()
 			doneCh <- nil
 		case <-proxy.Exited():
 			doneCh <- errors.New("envoy proxy exited unexpectedly")

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -170,7 +170,9 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 			if err := proxy.Stop(); err != nil {
 				cdp.logger.Error("failed to stop proxy", "error", err)
 			}
-			dnsServer.Stop()
+			if dnsServer != nil {
+				dnsServer.Stop()
+			}
 			doneCh <- nil
 		case <-proxy.Exited():
 			doneCh <- errors.New("envoy proxy exited unexpectedly")

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -146,6 +146,11 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 	}
 	cdp.logger.Debug("generated envoy bootstrap config", "config", string(cfg))
 
+	if err = cdp.startDNSProxy(ctx); err != nil {
+		cdp.logger.Error("failed to start the dns proxy", "error", err)
+		return err
+	}
+
 	proxy, err := envoy.NewProxy(cdp.envoyProxyConfig(cfg))
 	if err != nil {
 		cdp.logger.Error("failed to create new proxy", "error", err)

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -172,9 +172,11 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create dns server: %w", err)
 	}
 	if err = dnsServer.Run(); err != nil {
-		cdp.logger.Error("failed to run the dns proxy", "error", err)
-		return fmt.Errorf("failed to run the dns proxy: %w", err)
-
+		if err != dns.ErrServerDisabled {
+			cdp.logger.Error("failed to run the dns proxy", "error", err)
+			return fmt.Errorf("failed to run the dns proxy: %w", err)
+		}
+		cdp.logger.Error("dns proxy disabled: set consulDNSPort to enable")
 	}
 
 	doneCh := make(chan error)

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -131,6 +131,14 @@ func TestNewConsulDPError(t *testing.T) {
 			expectErr: "non-local xDS bind address not allowed",
 		},
 		{
+			name: "non-local xds bind address",
+			modFn: func(c *Config) {
+				c.DNSServer.BindAddr = "1.2.3.4"
+				c.DNSServer.Port = 1
+			},
+			expectErr: "non-local DNS proxy bind address not allowed",
+		},
+		{
 			name: "no bearer token or path given",
 			modFn: func(c *Config) {
 				c.Consul.Credentials.Type = CredentialsTypeLogin

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -32,6 +32,9 @@ func validConfig() *Config {
 		XDSServer: &XDSServer{
 			BindAddress: "127.0.0.1",
 		},
+		DNSServer: &DNSServerConfig{
+			BindAddr: "127.0.0.1",
+		},
 	}
 }
 

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,0 +1,242 @@
+package dns
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"time"
+
+	"github.com/hashicorp/consul/proto-public/pbdns"
+	"github.com/hashicorp/go-hclog"
+)
+
+type DNSServerParams struct {
+	BindAddr string
+	Port     int
+	Logger   hclog.Logger
+	Client   pbdns.DNSServiceClient
+}
+
+type DNSServerInterface interface {
+	Run() error
+	Stop()
+	TcpPort() int
+	UdpPort() int
+}
+
+type DNSServer struct {
+	bindAddr net.IP
+	port     int
+
+	logger      hclog.Logger
+	client      pbdns.DNSServiceClient
+	connUDP     net.PacketConn
+	listenerTCP net.Listener
+	stopCh      chan (struct{})
+}
+
+func NewDNSServer(p DNSServerParams) (DNSServerInterface, error) {
+	s := &DNSServer{}
+	s.bindAddr = net.ParseIP(p.BindAddr)
+	if s.bindAddr == nil {
+		return nil, fmt.Errorf("error parsing specified dns bind addr '%s'", p.BindAddr)
+	}
+	s.port = p.Port
+	s.client = p.Client
+	s.logger = p.Logger.Named("dns-proxy")
+	return s, nil
+}
+
+func (d *DNSServer) TcpPort() int {
+	return int(d.listenerTCP.Addr().(*net.TCPAddr).Port)
+}
+
+func (d *DNSServer) UdpPort() int {
+	return int(d.connUDP.LocalAddr().(*net.UDPAddr).Port)
+}
+
+func (d *DNSServer) Run() error {
+	// 1. Setup udp listener
+	udpAddr := &net.UDPAddr{
+		Port: d.port,
+		IP:   d.bindAddr,
+	}
+	connUDP, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return fmt.Errorf("error listening for udp: %w", err)
+	}
+	d.connUDP = connUDP
+
+	// 2. Setup tcp listener
+	tcpAddr := &net.TCPAddr{
+		Port: d.port,
+		IP:   d.bindAddr,
+	}
+	listenerTCP, err := net.ListenTCP("tcp", tcpAddr)
+	if err != nil {
+		return fmt.Errorf("error listening to udp: %w", err)
+	}
+	d.listenerTCP = listenerTCP
+
+	// 3. Start go routines to handle dns proxying
+	go d.proxyUDP()
+	go d.proxyTCP()
+
+	// 4. Create stop channel for stopping server
+	d.stopCh = make(chan struct{})
+
+	d.logger.Info("running dns proxy", " udp port", d.UdpPort(), "tcp port", d.TcpPort())
+	return nil
+}
+
+func (d *DNSServer) proxyUDP() {
+	logger := d.logger.Named("udp")
+	for {
+		select {
+		case <-d.stopCh:
+			d.connUDP.Close()
+			return
+		default:
+		}
+		buf := make([]byte, 512)
+		d.connUDP.SetReadDeadline(time.Now().Add(time.Second * 10))
+		bytesRead, addr, err := d.connUDP.ReadFrom(buf)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				logger.Info("connection closed")
+				break
+			} else {
+				if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+					logger.Debug("timeout waiting for read", "error", err)
+				} else {
+					logger.Warn("error reading from conn", "error", err)
+				}
+				continue
+			}
+		}
+		// Parallelize responses
+		go d.queryConsulAndRespondUDP(buf[0:bytesRead], addr)
+	}
+}
+
+func (d *DNSServer) queryConsulAndRespondUDP(buf []byte, addr net.Addr) {
+	logger := d.logger.Named("udp")
+	req := &pbdns.QueryRequest{
+		Msg:      buf,
+		Protocol: pbdns.Protocol_PROTOCOL_UDP,
+	}
+
+	resp, err := d.client.Query(context.Background(), req)
+	if err != nil {
+		logger.Error("error resolving consul request", "error", err)
+		return
+	}
+	logger.Debug("dns messaged received from consul", "length", len(resp.Msg))
+	_, err = d.connUDP.WriteTo(resp.Msg, addr)
+	if err != nil {
+		logger.Error("error sending response", "error", err)
+		return
+	}
+}
+
+func (d *DNSServer) proxyTCP() {
+	defer d.listenerTCP.Close()
+	for {
+		select {
+		case <-d.stopCh:
+			return
+		default:
+		}
+		c, err := d.listenerTCP.Accept()
+		if err != nil {
+			d.logger.Warn("failure to accept tcp connection", "error", err)
+		}
+		go d.proxyTCPAcceptedConn(c, d.client)
+	}
+}
+
+func (d *DNSServer) proxyTCPAcceptedConn(conn net.Conn, client pbdns.DNSServiceClient) {
+	defer conn.Close()
+	logger := d.logger.Named("tcp")
+	for {
+		select {
+		case <-d.stopCh:
+			return
+		default:
+		}
+		err := conn.SetReadDeadline(time.Now().Add(time.Second * 5))
+		if err != nil {
+			logger.Error("failure to set read deadline on connection", "error", err)
+			return
+		}
+
+		// Read in the size of the incoming packet to allocate enough mem to handle it
+		var prefixSize uint16
+		err = binary.Read(conn, binary.BigEndian, &prefixSize)
+		if err != nil {
+			if err == io.EOF {
+				logger.Debug("ending connection after EOF", "error", err)
+			} else {
+				logger.Error("failure to read", "error", err)
+			}
+			return
+		}
+
+		logger.Debug("request from remote addr received", "remote_addr",
+			conn.RemoteAddr().String(), "local_addr", conn.LocalAddr().String())
+
+		size := prefixSize
+		logger.Debug("total data length of tcp dns request", "size", size)
+		// Now that we know how much space we need, allocate a byte array to read the
+		// remaining data in.
+		data := make([]byte, size)
+		_, err = io.ReadFull(conn, data)
+		if err != nil {
+			logger.Error("error reading full tcp dns request ", "error", err)
+			// We can try reading it again but if this is a read timeout we don't necessarily want
+			// to close the connection
+			continue
+		}
+
+		// Now that we have the request we can forward the dnsrequest to consul
+		req := &pbdns.QueryRequest{
+			Msg:      data,
+			Protocol: pbdns.Protocol_PROTOCOL_TCP,
+		}
+		resp, err := client.Query(context.Background(), req)
+		if err != nil {
+			logger.Error("error resolving consul request", "error", err)
+			return
+		}
+		logger.Debug("total data length of dns response from consul", "size", len(resp.Msg))
+
+		// This is a guard and shouldn't happen but if the response is > 65535
+		// then we will just close the connection.
+		// Source: RFC1035 4.2.2.
+		if len(resp.Msg) > math.MaxUint16 {
+			logger.Error("consul response too large for DNS spec", "error", err)
+			return
+		}
+
+		// TCP DNS requests allcate a two byte length field prefixed to the message.
+		// Source: RFC1035 4.2.2.
+		err = binary.Write(conn, binary.BigEndian, uint16(len(resp.Msg)))
+		if err != nil {
+			logger.Warn("error writing length", "error", err)
+			return
+		}
+		_, err = conn.Write(resp.Msg)
+		if err != nil {
+			logger.Error("error writing response", "error", err)
+			return
+		}
+	}
+}
+
+func (d *DNSServer) Stop() {
+	close(d.stopCh)
+}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -124,7 +124,11 @@ func (d *DNSServer) proxyUDP() {
 		default:
 		}
 		buf := make([]byte, 512)
-		d.connUDP.SetReadDeadline(time.Now().Add(time.Second * 10))
+		err := d.connUDP.SetReadDeadline(time.Now().Add(time.Second * 10))
+		if err != nil {
+			logger.Error("failure to set read deadline on connection", "error", err)
+			return
+		}
 		bytesRead, addr, err := d.connUDP.ReadFrom(buf)
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -116,7 +116,7 @@ func (d *DNSServer) Start(ctx context.Context) error {
 	}
 	listenerTCP, err := net.ListenTCP("tcp", tcpAddr)
 	if err != nil {
-		return fmt.Errorf("error listening to udp: %w", err)
+		return fmt.Errorf("error listening to tcp: %w", err)
 	}
 	d.listenerTCP = listenerTCP
 
@@ -165,7 +165,7 @@ func (d *DNSServer) proxyUDP(ctx context.Context) {
 		err := d.connUDP.SetReadDeadline(time.Now().Add(time.Second * 10))
 		if err != nil {
 			logger.Error("failure to set read deadline on connection", "error", err)
-			return
+			continue
 		}
 		bytesRead, addr, err := d.connUDP.ReadFrom(buf)
 		if err != nil {

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -42,6 +42,26 @@ func genRandomBytes(size int) (blk []byte) {
 	rand.Read(blk)
 	return blk
 }
+
+func (s *DNSTestSuite) Test_DisabledServer() {
+	mockedDNSConsulClient := pbdns.NewMockDNSServiceClient(s.T())
+	server, err := NewDNSServer(DNSServerParams{
+		BindAddr: "127.0.0.1",
+		Port:     -1, // disabled server
+		Logger:   hclog.Default(),
+		Client:   mockedDNSConsulClient,
+	})
+	if err != nil {
+		s.T().FailNow()
+	}
+	err = server.Run()
+	s.Require().Equal(ErrServerDisabled, err)
+	s.Require().Equal(server.TcpPort(), -1)
+	s.Require().Equal(server.UdpPort(), -1)
+	server.Stop()
+
+}
+
 func (s *DNSTestSuite) Test_ServerStop() {
 	mockedDNSConsulClient := pbdns.NewMockDNSServiceClient(s.T())
 	server, err := NewDNSServer(DNSServerParams{

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -1,0 +1,262 @@
+package dns
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/proto-public/pbdns"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockedNetConn struct {
+	net.Conn
+	mock.Mock
+}
+
+type DNSTestSuite struct {
+	suite.Suite
+}
+
+// func (s *DNSTestSuite) SetupTest() {
+
+// }
+
+// func (s *DNSTestSuite) AfterTest() {
+
+// }
+
+func TestDNS_suite(t *testing.T) {
+	suite.Run(t, new(DNSTestSuite))
+}
+
+func genRandomBytes(size int) (blk []byte) {
+	blk = make([]byte, size)
+	rand.Read(blk)
+	return blk
+}
+func (s *DNSTestSuite) Test_ServerStop() {
+	mockedDNSConsulClient := pbdns.NewMockDNSServiceClient(s.T())
+	server, err := NewDNSServer(DNSServerParams{
+		BindAddr: "127.0.0.1",
+		Port:     0, // let the os choose a port
+		Logger:   hclog.Default(),
+		Client:   mockedDNSConsulClient,
+	})
+	if err != nil {
+		s.T().FailNow()
+	}
+	err = server.Run()
+	if err != nil {
+		s.T().FailNow()
+	}
+	server.Stop()
+
+	s.Require().Eventually(func() bool {
+		port := server.TcpPort()
+		addr := fmt.Sprintf("127.0.0.1:%v", port)
+		_, err := net.Dial("tcp", addr)
+		s.T().Logf("dial error: %v", err)
+		return err != nil
+	}, time.Second*20, time.Second, "Failure to shut down tcp")
+
+	s.Require().Eventually(func() bool {
+		port := server.TcpPort()
+		addr := fmt.Sprintf("127.0.0.1:%v", port)
+		c, _ := net.Dial("udp", addr)
+		c.Write([]byte("here"))
+		p := make([]byte, 512)
+		_, err = c.Read(p)
+		s.T().Logf("read udp error: %v", err)
+		return err != nil
+	}, time.Second*20, time.Second, "Failure to shut down udp")
+}
+
+func (s *DNSTestSuite) Test_UDPProxy() {
+	mockedDNSConsulClient := pbdns.NewMockDNSServiceClient(s.T())
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	connUdp, err := net.ListenUDP("udp", addr)
+	s.Require().NoError(err)
+	stopChan := make(chan struct{})
+	defer func() { stopChan <- struct{}{} }()
+
+	server := DNSServer{
+		client:  mockedDNSConsulClient,
+		connUDP: connUdp,
+		logger:  hclog.Default(),
+		stopCh:  stopChan,
+	}
+
+	go server.proxyUDP()
+
+	testCases := map[string]struct {
+		dnsRequest   []byte
+		dnsResp      []byte
+		expected     error
+		largeResp    error
+		expectedGRPC error
+	}{
+
+		"happy path": {
+			dnsRequest: genRandomBytes(512),
+			dnsResp:    genRandomBytes(50),
+		},
+		"happy large response path": {
+			dnsRequest: genRandomBytes(50),
+			dnsResp:    genRandomBytes(9216), // net.inet.udp.maxdgram for macs
+		},
+		"bad consul response too large": {
+			dnsRequest: genRandomBytes(50),
+			dnsResp:    genRandomBytes(65536),
+			expected:   errors.New("timeout"),
+		},
+		"bad consul response": {
+			dnsRequest:   genRandomBytes(512),
+			dnsResp:      genRandomBytes(50),
+			expectedGRPC: errors.New("timeout"),
+		},
+	}
+
+	for name, tc := range testCases {
+		s.Run(name, func() {
+
+			req := tc.dnsRequest
+			resp := tc.dnsResp
+
+			clientResp := &pbdns.QueryResponse{
+				Msg: resp,
+			}
+
+			mockedDNSConsulClient.On("Query", mock.Anything, mock.Anything).
+				Return(clientResp, tc.expectedGRPC).Once()
+			addr := fmt.Sprintf("127.0.0.1:%v", server.UdpPort())
+
+			conn, err := net.Dial("udp", addr)
+
+			s.Require().NoError(err)
+
+			n, err := conn.Write(req)
+			if err != nil {
+				s.T().Logf("error: %v", err.Error())
+			}
+			s.T().Logf("written %v", n)
+			p := make([]byte, 9216)
+			conn.SetReadDeadline(time.Now().Add(time.Second * 1))
+			lengthRead, err := conn.Read(p)
+			s.T().Logf("read %v", lengthRead)
+			if tc.expectedGRPC != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, tc.expectedGRPC.Error())
+			} else if tc.expected != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, tc.expected.Error())
+				return
+			} else {
+				s.Require().NoError(err, "exchange error")
+				s.Require().EqualValues(resp, p[0:lengthRead])
+				s.Require().Equal(lengthRead, len(resp))
+			}
+			conn.Close()
+		})
+	}
+
+}
+
+func (s *DNSTestSuite) Test_ProxydnsTCP() {
+	mockedDNSConsulClient := pbdns.NewMockDNSServiceClient(s.T())
+	addr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	listenerTCP, err := net.ListenTCP("tcp", addr)
+	s.Require().NoError(err)
+
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	server := DNSServer{
+		client:      mockedDNSConsulClient,
+		listenerTCP: listenerTCP,
+		logger:      hclog.Default(),
+		stopCh:      stopChan,
+	}
+
+	go server.proxyTCP()
+
+	testCases := map[string]struct {
+		dnsRequest   []byte
+		dnsResp      []byte
+		expected     error
+		largeResp    error
+		expectedGRPC error
+	}{
+		"happy path": {
+			dnsRequest: genRandomBytes(50),
+			dnsResp:    genRandomBytes(50),
+		},
+		"happy path large ": {
+			dnsRequest: genRandomBytes(50),
+			dnsResp:    genRandomBytes(65467),
+		},
+		"happy path large dns": {
+			dnsRequest: genRandomBytes(50),
+			dnsResp:    genRandomBytes(65536),
+			largeResp:  errors.New("EOF"),
+		},
+		"no consul server response": {
+			dnsRequest:   genRandomBytes(50),
+			dnsResp:      genRandomBytes(50),
+			expectedGRPC: errors.New("EOF"),
+		},
+	}
+	for name, tc := range testCases {
+		s.Run(name, func() {
+
+			req := tc.dnsRequest
+			resp := tc.dnsResp
+
+			clientResp := &pbdns.QueryResponse{
+				Msg: resp,
+			}
+
+			mockedDNSConsulClient.On("Query", mock.Anything, mock.Anything).
+				Return(clientResp, tc.expectedGRPC).
+				Once()
+			addr := fmt.Sprintf("127.0.0.1:%v", server.TcpPort())
+
+			conn, err := net.Dial("tcp", addr)
+			s.Require().NoError(err)
+
+			defer conn.Close()
+			binary.Write(conn, binary.BigEndian, uint16(len(req)))
+			conn.Write(req)
+
+			var length uint16
+			err = binary.Read(conn, binary.BigEndian, &length)
+			if tc.largeResp != nil || tc.expectedGRPC != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, "EOF")
+				return
+			}
+			s.Require().NoError(err)
+
+			p := make([]byte, length)
+			v, err := io.ReadFull(conn, p)
+
+			if tc.expected != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, tc.expected.Error())
+			} else if tc.expectedGRPC != nil {
+				s.Require().Error(err)
+				s.Require().ErrorContains(err, "EOF")
+			} else {
+				s.Require().NoError(err, "exchange error")
+				s.Require().EqualValues(resp, p)
+				s.Require().Equal(v, len(resp))
+			}
+		})
+	}
+}

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -39,7 +39,7 @@ func TestDNS_suite(t *testing.T) {
 
 func genRandomBytes(size int) (blk []byte) {
 	blk = make([]byte, size)
-	rand.Read(blk)
+	_, _ = rand.Read(blk)
 	return blk
 }
 
@@ -91,7 +91,7 @@ func (s *DNSTestSuite) Test_ServerStop() {
 		port := server.TcpPort()
 		addr := fmt.Sprintf("127.0.0.1:%v", port)
 		c, _ := net.Dial("udp", addr)
-		c.Write([]byte("here"))
+		_, _ = c.Write([]byte("here"))
 		p := make([]byte, 512)
 		_, err = c.Read(p)
 		s.T().Logf("read udp error: %v", err)
@@ -168,7 +168,7 @@ func (s *DNSTestSuite) Test_UDPProxy() {
 			}
 			s.T().Logf("written %v", n)
 			p := make([]byte, 9216)
-			conn.SetReadDeadline(time.Now().Add(time.Second * 1))
+			_ = conn.SetReadDeadline(time.Now().Add(time.Second * 1))
 			lengthRead, err := conn.Read(p)
 			s.T().Logf("read %v", lengthRead)
 			if tc.expectedGRPC != nil {
@@ -251,8 +251,8 @@ func (s *DNSTestSuite) Test_ProxydnsTCP() {
 			s.Require().NoError(err)
 
 			defer conn.Close()
-			binary.Write(conn, binary.BigEndian, uint16(len(req)))
-			conn.Write(req)
+			_ = binary.Write(conn, binary.BigEndian, uint16(len(req)))
+			_, _ = conn.Write(req)
 
 			var length uint16
 			err = binary.Read(conn, binary.BigEndian, &length)

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -85,7 +85,7 @@ func (s *DNSTestSuite) Test_ServerStop() {
 		_, err := net.Dial("tcp", addr)
 		s.T().Logf("dial error: %v", err)
 		return err != nil
-	}, time.Second*20, time.Second, "Failure to shut down tcp")
+	}, time.Second*5, time.Second, "Failure to shut down tcp")
 
 	s.Require().Eventually(func() bool {
 		port := server.TcpPort()
@@ -96,7 +96,7 @@ func (s *DNSTestSuite) Test_ServerStop() {
 		_, err = c.Read(p)
 		s.T().Logf("read udp error: %v", err)
 		return err != nil
-	}, time.Second*20, time.Second, "Failure to shut down udp")
+	}, time.Second*5, time.Second, "Failure to shut down udp")
 }
 
 func (s *DNSTestSuite) Test_UDPProxy() {


### PR DESCRIPTION
This PR adds support for a transparent DNS proxy to consul for both udp and tcp. It is dependent on [this](https://github.com/hashicorp/consul/pull/14811) being merged first.

This PR is best viewed commit by commit: 
1. [d3c9609](https://github.com/hashicorp/consul-dataplane/pull/22/commits/d3c960962248c37f0db942084117d93f1a0a1837) pulls in the [change](https://github.com/hashicorp/consul/pull/14811) from consul. 
2. [ee58710](https://github.com/hashicorp/consul-dataplane/pull/22/commits/ee587107b7c68f3c4a220eda12eb7dfa026725e9) adds in the dns module for listening on both udp and tcp
3. [63462c9](https://github.com/hashicorp/consul-dataplane/pull/22/commits/63462c9a84cad8ef45f0ce37210067dba180e405) wires up the dns proxy to the consul dataplane instance
4. [a488b44](https://github.com/hashicorp/consul-dataplane/pull/22/commits/a488b446ee5d66b990f50769c5db6801189c4e9e) Adds the ability to disable the server by default

The `consul-dns-bind-addr` and the `consul-dns-port` can configure the dns port that the proxy will listen on. If no consul-dns-port is set the server will be disabled. By default the server is disabled. 