### PR TITLE
Disable the redhat image for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,21 +197,21 @@ jobs:
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}-${{ github.sha }}
 
-  build-docker-redhat:
-    name: Docker UBI Image Build (for Red Hat Certified Container Registry)
-    needs:
-      - get-product-version
-      - build-linux
-    runs-on: ubuntu-latest
-    env:
-      repo: ${{github.event.repository.name}}
-      version: ${{needs.get-product-version.outputs.product-version}}
+  #build-docker-redhat:
+  #  name: Docker UBI Image Build (for Red Hat Certified Container Registry)
+  #  needs:
+  #    - get-product-version
+  #    - build-linux
+  #  runs-on: ubuntu-latest
+  #  env:
+  #    repo: ${{github.event.repository.name}}
+  #    version: ${{needs.get-product-version.outputs.product-version}}
 
-    steps:
-      - uses: actions/checkout@v2
-      - uses: hashicorp/actions-docker-build@v1
-        with:
-          version: ${{env.version}}
-          target: release-ubi
-          arch: amd64
-          redhat_tag: scan.connect.redhat.com/ospid-62211e0d8bf2cabc69a39c7d/${{env.repo}}:${{env.version}}-ubi
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - uses: hashicorp/actions-docker-build@v1
+  #      with:
+  #        version: ${{env.version}}
+  #        target: release-ubi
+  #        arch: amd64
+  #        redhat_tag: scan.connect.redhat.com/ospid-62211e0d8bf2cabc69a39c7d/${{env.repo}}:${{env.version}}-ubi


### PR DESCRIPTION
The redhat catalog repo for consul-dataplane is not quite ready, which blocks promoting to production