### PR TITLE
Make metrics server context aware and centralize into metrics config

### DIFF
--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/consul-dataplane/pkg/consuldp"
 	"github.com/hashicorp/consul-dataplane/pkg/version"
+	"github.com/hashicorp/go-hclog"
 )
 
 var (
@@ -223,10 +224,12 @@ func main() {
 			Port:     consulDNSPort,
 		},
 	}
+
 	consuldpInstance, err := consuldp.NewConsulDP(consuldpCfg)
 	if err != nil {
 		log.Fatal(err)
 	}
+	ctx := hclog.WithContext(ctx, consuldpInstance.Logger)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/consul-dataplane/pkg/consuldp"
 	"github.com/hashicorp/consul-dataplane/pkg/version"
-	"github.com/hashicorp/go-hclog"
 )
 
 var (
@@ -229,7 +228,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ctx := hclog.WithContext(ctx, consuldpInstance.Logger)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -30,12 +30,6 @@ type httpGetter interface {
 	Get(string) (*http.Response, error)
 }
 
-type metricsServer struct {
-	httpServer *http.Server
-	client     httpGetter
-	exitedCh   chan struct{}
-}
-
 // ConsulDataplane represents the consul-dataplane process
 type ConsulDataplane struct {
 	logger          hclog.Logger
@@ -44,7 +38,7 @@ type ConsulDataplane struct {
 	dpServiceClient pbdataplane.DataplaneServiceClient
 	xdsServer       *xdsServer
 	aclToken        string
-	metricsServer   *metricsServer
+	metricsConfig   *metricsConfig
 }
 
 // NewConsulDP creates a new instance of ConsulDataplane
@@ -117,6 +111,7 @@ func validateConfig(cfg *Config) error {
 }
 
 func (cdp *ConsulDataplane) Run(ctx context.Context) error {
+	ctx = hclog.WithContext(ctx, cdp.logger)
 	cdp.logger.Info("started consul-dataplane process")
 
 	tls, err := cdp.cfg.Consul.TLS.Load()
@@ -183,18 +178,9 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to run proxy: %w", err)
 	}
 
-	cdp.setupMetricsServer()
-	if cdp.cfg.Telemetry.UseCentralConfig {
-		switch {
-		case bootstrapCfg.PrometheusBindAddr != "":
-			go cdp.startMetricsServer()
-			defer cdp.stopMetricsServer()
-		case bootstrapCfg.StatsdURL != "":
-			// TODO: send merged metrics
-		case bootstrapCfg.DogstatsdURL != "":
-			// TODO: send merged metrics
-		}
-	}
+	cdp.metricsConfig = NewMetricsConfig(cdp.cfg.Telemetry)
+
+	cdp.metricsConfig.startMetrics(ctx, bootstrapCfg)
 
 	doneCh := make(chan error)
 	go func() {
@@ -208,7 +194,7 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 				cdp.logger.Error("failed to stop proxy", "error", err)
 			}
 			doneCh <- errors.New("xDS server exited unexpectedly")
-		case <-cdp.metricsServerExited():
+		case <-cdp.metricsConfig.metricsServerExited():
 			doneCh <- errors.New("metrics server exited unexpectedly")
 		}
 	}()


### PR DESCRIPTION
Trying to make sure everything uses the ctx that is passed down and that we exit based off if the context is done.

Also centralizing the logic for metrics inside the `metricsConfig` struct so that the `ConsuldDataplaneInstance`  doesn't get too large over time. 

This also mimics consul's metric config so we keep the code bases semi similar. 