### PR TITLE
ci: Fix changelog-checker GHA workflow

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -25,11 +25,9 @@ jobs:
           fetch-depth: 0 # by default the checkout action doesn't checkout all branches
       - name: Check for changelog entry in diff
         run: |
-          pull_request_base_main=$(expr "${{ github.event.pull_request.base.ref }}" = "main")
-
           # check if there is a diff in the .changelog directory
           # for PRs against the main branch, the changelog file name should match the PR number
-          if [ pull_request_base_main ]; then
+          if [ "${{ github.event.pull_request.base.ref }}" = "${{ github.event.repository.default_branch }}" ]; then
             enforce_matching_pull_request_number="matching this PR number "
             changelog_file_path=".changelog/${{ github.event.pull_request.number }}.txt"
           else


### PR DESCRIPTION
This is a follow-on to https://github.com/hashicorp/consul/pull/14842. I noticed that this repo borrowed its changelog checker workflow from Consul and so I thought I'd port the fix from the aforementioned Consul PR so that this too can be fixed.

See the description in the other PR for more details.