### PR TITLE
Consul dataplane metrics and metrics cache sink

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
-	github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9
+	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa
 	github.com/hashicorp/consul/proto-public v0.1.1
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,14 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9 h1:1e2vy4aPfxun9DG808QjXtShksPoaQsHvyxhVOyjeRI=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f h1:niyK8S2Vb48YumFkxsqzSl+72tDXgvpAEO6KrL3WwAw=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045452-ab8e92ce71bf h1:LIy45v2rDQ9gyrSwVwmPJscVv9QVhXSVUi2tv/2QqDE=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045452-ab8e92ce71bf/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045822-1cb0f89e3790 h1:mH1+tWnJ5JJFaDW2DCYnbkYdDcTyk4iO5M+QGKzrPME=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045822-1cb0f89e3790/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa h1:ZQkD1mMJyrpYvy5S+si9S6hvymcOSM7+leLHL0ltG1c=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=
 github.com/hashicorp/consul/proto-public v0.1.1/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=

--- a/go.sum
+++ b/go.sum
@@ -148,14 +148,6 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9 h1:1e2vy4aPfxun9DG808QjXtShksPoaQsHvyxhVOyjeRI=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f h1:niyK8S2Vb48YumFkxsqzSl+72tDXgvpAEO6KrL3WwAw=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220922180412-01c5be1c636f/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045452-ab8e92ce71bf h1:LIy45v2rDQ9gyrSwVwmPJscVv9QVhXSVUi2tv/2QqDE=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045452-ab8e92ce71bf/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045822-1cb0f89e3790 h1:mH1+tWnJ5JJFaDW2DCYnbkYdDcTyk4iO5M+QGKzrPME=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221012045822-1cb0f89e3790/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa h1:ZQkD1mMJyrpYvy5S+si9S6hvymcOSM7+leLHL0ltG1c=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -241,7 +242,7 @@ func (m *metricsConfig) getPromDefaults() (*prom.Registry, *prometheus.Prometheu
 		Registerer:       reg,
 		GaugeDefinitions: gauges,
 		// CounterDefinitions: ,
-		// SummaryDefinitions: ,
+		SummaryDefinitions: discovery.Summaries,
 	}
 	return r, opts, nil
 }

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -125,7 +125,10 @@ func (m *metricsConfig) startMetrics(ctx context.Context, bcfg *bootstrap.Bootst
 		}
 	} else {
 		// send metrics to black hole if we they aren't being configured.
-		m.cacheSink.SetSink(&metrics.BlackholeSink{})
+		err := m.cacheSink.SetSink(&metrics.BlackholeSink{})
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -263,7 +266,10 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 		}
 		// we set the cache sink to be the prometheus sink to
 		// flush out metrics recorded to the cache.
-		m.cacheSink.SetSink(sink)
+		err = m.cacheSink.SetSink(sink)
+		if err != nil {
+			return err
+		}
 
 		go m.runCDPMetricsServer(r)
 

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -125,10 +125,8 @@ func (m *metricsConfig) startMetrics(ctx context.Context, bcfg *bootstrap.Bootst
 		}
 	} else {
 		// send metrics to black hole if we they aren't being configured.
-		err := m.cacheSink.SetSink(&metrics.BlackholeSink{})
-		if err != nil {
-			return err
-		}
+		m.cacheSink.SetSink(&metrics.BlackholeSink{})
+
 	}
 
 	return nil
@@ -265,11 +263,8 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 			return err
 		}
 		// we set the cache sink to be the prometheus sink to
-		// flush out metrics recorded to the cache.
-		err = m.cacheSink.SetSink(sink)
-		if err != nil {
-			return err
-		}
+		// replay out metrics recorded to the cache.
+		m.cacheSink.SetSink(sink)
 
 		go m.runCDPMetricsServer(r)
 

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
@@ -237,8 +238,8 @@ func (m *metricsConfig) getPromDefaults() (*prom.Registry, *prometheus.Prometheu
 		return nil, nil, err
 	}
 	opts := &prometheus.PrometheusOpts{
-		Registerer: reg,
-		// GaugeDefinitions: ,
+		Registerer:       reg,
+		GaugeDefinitions: gauges,
 		// CounterDefinitions: ,
 		// SummaryDefinitions: ,
 	}

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
-	"github.com/hashicorp/go-hclog"
-	prom "github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	metricscache "github.com/hashicorp/consul-dataplane/pkg/metrics-cache"
 )
 
 type Stats int
@@ -44,6 +44,7 @@ const (
 type metricsConfig struct {
 	logger hclog.Logger
 
+	cacheSink          *metricscache.Sink
 	cfg                *TelemetryConfig
 	envoyAdminAddr     string
 	envoyAdminBindPort int
@@ -62,13 +63,14 @@ type metricsConfig struct {
 	mu          sync.Mutex
 }
 
-func NewMetricsConfig(cfg *Config) *metricsConfig {
+func NewMetricsConfig(cfg *Config, cacheSink *metricscache.Sink) *metricsConfig {
 	return &metricsConfig{
 		mu:                 sync.Mutex{},
 		cfg:                cfg.Telemetry,
 		errorExitCh:        make(chan struct{}),
 		envoyAdminAddr:     cfg.Envoy.AdminBindAddress,
 		envoyAdminBindPort: cfg.Envoy.AdminBindPort,
+		cacheSink:          cacheSink,
 
 		client: &http.Client{
 			Timeout: 10 * time.Second,
@@ -119,6 +121,9 @@ func (m *metricsConfig) startMetrics(ctx context.Context, bcfg *bootstrap.Bootst
 		case bcfg.DogstatsdURL != "":
 			// TODO: send merged metrics
 		}
+	} else {
+		// send metrics to black hole if we they aren't being configured.
+		m.cacheSink.SetSink(&metrics.BlackholeSink{})
 	}
 
 	return nil
@@ -254,12 +259,9 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 		if err != nil {
 			return err
 		}
-		conf := metrics.DefaultConfig("consul_dataplane")
-		conf.EnableHostname = false
-		_, err = metrics.NewGlobal(conf, sink)
-		if err != nil {
-			return err
-		}
+		// we set the cache sink to be the prometheus sink to
+		// flush out metrics recorded to the cache.
+		m.cacheSink.SetSink(sink)
 
 		go m.runCDPMetricsServer(r)
 
@@ -276,7 +278,7 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 
 // runCDPMetricsServer takes a prom.Gatherer that will create a handler
 // for http calls to the metrics endpoint and return prometheus style metrics.
-// Eventually these metrics will be
+// Eventually these metrics will be scraped and merged.
 func (m *metricsConfig) runCDPMetricsServer(gather prom.Gatherer) {
 	m.cdpMetricsServer = &http.Server{
 		Addr: cdpMetricsBindAddr,

--- a/pkg/consuldp/stats.go
+++ b/pkg/consuldp/stats.go
@@ -1,0 +1,10 @@
+package consuldp
+
+import "github.com/armon/go-metrics/prometheus"
+
+var gauges = []prometheus.GaugeDefinition{
+	{
+		Name: []string{"envoy_connected"},
+		Help: "This will either be 0 or 1 depending on whether Envoy is currently running and connected to the local xDS listeners.",
+	},
+}

--- a/pkg/metrics-cache/metricscache.go
+++ b/pkg/metrics-cache/metricscache.go
@@ -1,0 +1,150 @@
+package metricscache
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/armon/go-metrics"
+)
+
+type metric struct {
+	key    []string
+	val    float32
+	labels []metrics.Label
+}
+
+// Sink is a temporary sink that caches metrics until a real sink is set in SetSink
+type Sink struct {
+	gauges   []metric
+	counters []metric
+	samples  []metric
+	keys     []metric
+
+	realSink metrics.MetricSink
+
+	mu        sync.Mutex
+	checkLock bool
+}
+
+// NewSink returns a pointer to a sink with empty cache
+func NewSink() *Sink {
+	return &Sink{
+		gauges:    []metric{},
+		counters:  []metric{},
+		samples:   []metric{},
+		keys:      []metric{},
+		mu:        sync.Mutex{},
+		checkLock: true, // we only need to check the lock if we haven't yet set the real sink
+	}
+}
+
+// SetGauge defaults to SetGaugeWithLabels
+func (s *Sink) SetGauge(key []string, val float32) {
+	s.SetGaugeWithLabels(key, val, nil)
+}
+
+// SetGaugeWithLabels sends metrics to the real sink otherwise caches them
+func (s *Sink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
+	if s.checkLock {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.SetGaugeWithLabels(key, val, labels)
+		return
+	}
+
+	s.gauges = append(s.gauges, metric{key: key, val: val, labels: labels})
+}
+
+// EmitKey sends metrics to the real sink otherwise caches them
+func (s *Sink) EmitKey(key []string, val float32) {
+	if s.checkLock {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.EmitKey(key, val)
+		return
+	}
+
+	s.keys = append(s.keys, metric{key: key, val: val})
+}
+
+// IncrCounter defaults to IncrCounterWithLabels
+func (s *Sink) IncrCounter(key []string, val float32) {
+	s.IncrCounterWithLabels(key, val, nil)
+
+}
+
+// IncrCounterWithLabels sends metrics to the real sink otherwise caches them
+func (s *Sink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {
+	if s.checkLock {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.IncrCounterWithLabels(key, val, labels)
+		return
+	}
+	s.counters = append(s.counters, metric{key: key, val: val, labels: labels})
+}
+
+// AddSample defaults to AddSampleWithLabels
+func (s *Sink) AddSample(key []string, val float32) {
+	s.AddSampleWithLabels(key, val, nil)
+}
+
+// AddSampleWithLabels sends metrics to the real sink otherwise caches them
+func (s *Sink) AddSampleWithLabels(key []string, val float32, labels []metrics.Label) {
+	if s.checkLock {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.AddSampleWithLabels(key, val, labels)
+		return
+	}
+	s.samples = append(s.samples, metric{key: key, val: val, labels: labels})
+}
+
+// SetSink takes a sink and will ensure that the sink sets the value
+// and then starts forwarding metrics on to the realSink once called.
+// It will also replay all the cached metrics and send the to the realSink
+func (s *Sink) SetSink(newSink metrics.MetricSink) error {
+	if s.realSink != nil {
+		return errors.New("sink can only be set once")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.checkLock = false
+	s.realSink = newSink
+	s.Replay()
+	return nil
+}
+
+// Replay will send cached metrics to the realsink. Once done it will empty the cached store.
+func (s *Sink) Replay() {
+	if s.realSink != nil {
+		for _, sample := range s.samples {
+			s.realSink.AddSampleWithLabels(sample.key, sample.val, sample.labels)
+		}
+		s.samples = []metric{} // empty out after replaying samples
+		for _, gauge := range s.gauges {
+			s.realSink.SetGaugeWithLabels(gauge.key, gauge.val, gauge.labels)
+		}
+		s.gauges = []metric{} // empty out after replaying gauges
+		for _, counter := range s.counters {
+			s.realSink.IncrCounterWithLabels(counter.key, counter.val, counter.labels)
+		}
+		s.counters = []metric{} // empty out after replaying counters
+		for _, key := range s.keys {
+			s.realSink.EmitKey(key.key, key.val)
+		}
+		s.keys = []metric{} // empty out after replaying keys
+	}
+}

--- a/pkg/metrics-cache/metricscache.go
+++ b/pkg/metrics-cache/metricscache.go
@@ -13,7 +13,8 @@ type metric struct {
 	labels []metrics.Label
 }
 
-// Sink is a temporary sink that caches metrics until a real sink is set in SetSink
+// Sink is a temporary sink that caches metrics until a real sink is set in SetSink.
+// it implements the metrics.MetricSink interface
 type Sink struct {
 	gauges   []metric
 	counters []metric

--- a/pkg/metrics-cache/metricscache_test.go
+++ b/pkg/metrics-cache/metricscache_test.go
@@ -46,7 +46,8 @@ func TestMetricsCache_BasicPath(t *testing.T) {
 	sink.IncrCounter([]string{"mycounter"}, 16)
 
 	realSink := metrics.NewInmemSink(time.Second, time.Second*1)
-	sink.SetSink(realSink)
+	err := sink.SetSink(realSink)
+	require.NoError(t, err)
 	sink.IncrCounter([]string{"mycounter"}, 32)
 
 	data := realSink.Data()
@@ -106,7 +107,8 @@ func TestMetricsCache_ParallelTest(t *testing.T) {
 		t.Logf("done")
 	}()
 
-	sink.SetSink(realSink)
+	err := sink.SetSink(realSink)
+	require.NoError(t, err)
 	time.Sleep(time.Second)
 
 	data := realSink.Data()

--- a/pkg/metrics-cache/metricscache_test.go
+++ b/pkg/metrics-cache/metricscache_test.go
@@ -83,7 +83,7 @@ func TestMetricsCache_ParallelTest(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 100; i++ {
-			sink.SetGauge([]string{"mygauge"}, float32(i))
+			sink.SetGauge([]string{"mygauge"}, float32(i+1))
 		}
 	}()
 
@@ -95,7 +95,7 @@ func TestMetricsCache_ParallelTest(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 100; i++ {
-			sink.EmitKey([]string{"mykey"}, 100)
+			sink.EmitKey([]string{"mykey"}, 1)
 		}
 	}()
 
@@ -118,9 +118,9 @@ func TestMetricsCache_ParallelTest(t *testing.T) {
 	mysamples := data[0].Samples["mysample"]
 	mykey := data[0].Points["mykey"]
 	mycounter := data[0].Counters["mycounter"]
-	require.NotEmpty(t, mygauge.Value, 100)
-	require.NotEmpty(t, mysamples.AggregateSample.Count, 100)
-	require.NotEmpty(t, mykey, 1)
-	require.NotEmpty(t, mycounter.AggregateSample.Count, 100)
+	require.EqualValues(t, 100, mygauge.Value)
+	require.EqualValues(t, 100, mysamples.AggregateSample.Count)
+	require.EqualValues(t, 100, len(mykey))
+	require.EqualValues(t, 100, mycounter.AggregateSample.Count)
 
 }

--- a/pkg/metrics-cache/metricscache_test.go
+++ b/pkg/metrics-cache/metricscache_test.go
@@ -1,0 +1,124 @@
+package metricscache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func validateMetrics(t *testing.T, data []*metrics.IntervalMetrics) {
+	require.NotEmpty(t, data)
+	// Gauge based off being set once at value of 1
+	mygauge := data[0].Gauges["mygauge"]
+	require.EqualValues(t, mygauge.Value, 1)
+
+	// Samples based off setting twice: once at 10, once at 110
+	mysamples := data[0].Samples["mysample"]
+	require.EqualValues(t, 2, mysamples.AggregateSample.Count)
+	require.EqualValues(t, 110, mysamples.AggregateSample.Sum)
+	require.EqualValues(t, 10, mysamples.AggregateSample.Min)
+	require.EqualValues(t, 100, mysamples.AggregateSample.Max)
+
+	// Keys based off a single value of 3
+	mykey := data[0].Points["mykey"]
+	require.EqualValues(t, mykey[0], 3)
+
+	// counter's based off being set four times with values 4, 8, 16, 32
+	mycounter := data[0].Counters["mycounter"]
+	require.EqualValues(t, 4, mycounter.AggregateSample.Count)
+	require.EqualValues(t, 60, mycounter.AggregateSample.Sum)
+	require.EqualValues(t, 4, mycounter.AggregateSample.Min)
+	require.EqualValues(t, 32, mycounter.AggregateSample.Max)
+
+}
+
+func TestMetricsCache_BasicPath(t *testing.T) {
+	sink := NewSink()
+
+	sink.SetGauge([]string{"mygauge"}, 1)
+	sink.AddSample([]string{"mysample"}, 10)
+	sink.AddSample([]string{"mysample"}, 100)
+	sink.EmitKey([]string{"mykey"}, 3)
+	sink.IncrCounter([]string{"mycounter"}, 4)
+	sink.IncrCounter([]string{"mycounter"}, 8)
+	sink.IncrCounter([]string{"mycounter"}, 16)
+
+	realSink := metrics.NewInmemSink(time.Second, time.Second*1)
+	sink.SetSink(realSink)
+	sink.IncrCounter([]string{"mycounter"}, 32)
+
+	data := realSink.Data()
+	validateMetrics(t, data)
+
+	// Check before the interval is up if setting values will increase the metrics
+	sink.IncrCounter([]string{"mycounter"}, 2)
+	data = realSink.Data()
+	mycounter := data[0].Counters["mycounter"]
+	require.EqualValues(t, 5, mycounter.AggregateSample.Count)
+	require.EqualValues(t, 62, mycounter.AggregateSample.Sum)
+	require.EqualValues(t, 2, mycounter.AggregateSample.Min)
+	require.EqualValues(t, 32, mycounter.AggregateSample.Max)
+
+	time.Sleep(time.Second)
+
+	sink.SetGauge([]string{"mygauge"}, 1)
+	sink.AddSample([]string{"mysample"}, 10)
+	sink.AddSample([]string{"mysample"}, 100)
+	sink.EmitKey([]string{"mykey"}, 3)
+	sink.IncrCounter([]string{"mycounter"}, 4)
+	sink.IncrCounter([]string{"mycounter"}, 8)
+	sink.IncrCounter([]string{"mycounter"}, 16)
+	sink.IncrCounter([]string{"mycounter"}, 32)
+
+	data = realSink.Data()
+	validateMetrics(t, data)
+}
+
+func TestMetricsCache_ParallelTest(t *testing.T) {
+	sink := NewSink()
+	realSink := metrics.NewInmemSink(time.Second, time.Second*20)
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			sink.SetGauge([]string{"mygauge"}, float32(i))
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			sink.AddSample([]string{"mysample"}, 1)
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			sink.EmitKey([]string{"mykey"}, 100)
+		}
+	}()
+
+	go func() {
+		t.Logf("starting")
+		for i := 0; i < 100; i++ {
+			sink.IncrCounter([]string{"mycounter"}, 1)
+		}
+		t.Logf("done")
+	}()
+
+	sink.SetSink(realSink)
+	time.Sleep(time.Second)
+
+	data := realSink.Data()
+
+	require.NotEmpty(t, data)
+	mygauge := data[0].Gauges["mygauge"]
+	mysamples := data[0].Samples["mysample"]
+	mykey := data[0].Points["mykey"]
+	mycounter := data[0].Counters["mycounter"]
+	require.NotEmpty(t, mygauge.Value, 100)
+	require.NotEmpty(t, mysamples.AggregateSample.Count, 100)
+	require.NotEmpty(t, mykey, 1)
+	require.NotEmpty(t, mycounter.AggregateSample.Count, 100)
+
+}

--- a/pkg/metrics-cache/metricscache_test.go
+++ b/pkg/metrics-cache/metricscache_test.go
@@ -1,6 +1,7 @@
 package metricscache
 
 import (
+	"sync"
 	"testing"
 	"time"
 


### PR DESCRIPTION
This is dependent on this [changeset](https://github.com/hashicorp/consul-server-connection-manager/pull/16) being merged first and then re running a `go get github.com/hashicorp/consul-server-connection-manager/discovery` 

After the above this PR is best viewed commit by commit: 

1. 41d847806e0a093cad79a7216a2d7d4cffdb03e8 Adds in a metrics-cache sink. This is necessary because we need to start recording metrics before we know if the envoy configuration actually specified exporting metrics. This cache sink will store metrics until we have configured the metricsConfig and then it will forward all the metrics to the configured sink. 
2. 5f6eb1bcc7aeb25c99cd4a8b7c3b9addec822d56 this commit adds in the metrics-cache defined in 1. into the consul-dataplane and ensures we start recording metrics before we ever setup the real metrics sink.
3. 996cfd6c9404d756bb1949d07aa123f9d68f3dff this change set defines a prometheus definition for the envoy_connected metrics and adds it to the prometheus opts
4. c280835f460827f043eff993f59bed3174e94ffa this fetches the changesset above so we can add the exported summary definitions to the prometheus opts for the consul-dataplane metrics. 
5. 7cfcb52c3e76441161c4a3d85a061e107bd3ee20 fixes some linting errors. 

We are still missing the following metrics defined in the RFC but we can add them as the functionality becomes available: 
- consul_dataplane.roots_updates - This will be a counter of the number of roots updates received.
- consul_dataplane.certificate_create_duration - This will be a sample of the time spent getting a new certificate created. It includes both the time spent doing local cryptography as well as the gRPC call to the servers to sign the certificate.
- consul_dataplane.certificate_create_errors - This will be a counter that increases when an error is encountered. The most likely of these would be when that RPC is getting rate limited.
- consul_dataplane.certificate_expiration_minutes - This will be the number of minutes until the certificate will expire. This will be particularly useful in validating that certificate renewal is happening as desired and that the underlying mesh enabled service should be able to continue operating.

