### PR TITLE
Adding metricscache and recording of consul dataplane metrics

### DIFF
--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - run: go test ./...
   golangci:
     name: lint
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
-	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa
+	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415
 	github.com/hashicorp/consul/proto-public v0.1.1
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
-	github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9
+	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa
 	github.com/hashicorp/consul/proto-public v0.1.1
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9 h1:1e2vy4aPfxun9DG808QjXtShksPoaQsHvyxhVOyjeRI=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20220920152341-d96d0f93c5d9/go.mod h1:I56VZ1V7WN8/oPHswKDywfepvD7rB1RrTE4fRrNz3Wc=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa h1:ZQkD1mMJyrpYvy5S+si9S6hvymcOSM7+leLHL0ltG1c=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=
 github.com/hashicorp/consul/proto-public v0.1.1/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa h1:ZQkD1mMJyrpYvy5S+si9S6hvymcOSM7+leLHL0ltG1c=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221013001410-ac17f62a7baa/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415 h1:NZnQy0p2YjL9L+tsFqHWs4MubbDxCi4aJEFOI0uvaTo=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=
 github.com/hashicorp/consul/proto-public v0.1.1/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -239,8 +239,8 @@ func (m *metricsConfig) getPromDefaults() (*prom.Registry, *prometheus.Prometheu
 		return nil, nil, err
 	}
 	opts := &prometheus.PrometheusOpts{
-		Registerer: reg,
-		// GaugeDefinitions: ,
+		Registerer:       reg,
+		GaugeDefinitions: gauges,
 		// CounterDefinitions: ,
 		// SummaryDefinitions: ,
 	}

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -127,7 +127,7 @@ func (m *metricsConfig) startMetrics(ctx context.Context, bcfg *bootstrap.Bootst
 			// TODO: send merged metrics
 		}
 	} else {
-		// send metrics to black hole if we they aren't being configured.
+		// send metrics to black hole if they aren't being configured.
 		m.cacheSink.SetSink(&metrics.BlackholeSink{})
 
 	}

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
-	"github.com/hashicorp/go-multierror"
-
-	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
+	metricscache "github.com/hashicorp/consul-dataplane/pkg/metrics-cache"
 )
 
 type Stats int
@@ -44,6 +45,7 @@ const (
 type metricsConfig struct {
 	logger hclog.Logger
 
+	cacheSink          *metricscache.Sink
 	cfg                *TelemetryConfig
 	envoyAdminAddr     string
 	envoyAdminBindPort int
@@ -62,13 +64,14 @@ type metricsConfig struct {
 	mu          sync.Mutex
 }
 
-func NewMetricsConfig(cfg *Config) *metricsConfig {
+func NewMetricsConfig(cfg *Config, cacheSink *metricscache.Sink) *metricsConfig {
 	return &metricsConfig{
 		mu:                 sync.Mutex{},
 		cfg:                cfg.Telemetry,
 		errorExitCh:        make(chan struct{}),
 		envoyAdminAddr:     cfg.Envoy.AdminBindAddress,
 		envoyAdminBindPort: cfg.Envoy.AdminBindPort,
+		cacheSink:          cacheSink,
 
 		client: &http.Client{
 			Timeout: 10 * time.Second,
@@ -119,6 +122,10 @@ func (m *metricsConfig) startMetrics(ctx context.Context, bcfg *bootstrap.Bootst
 		case bcfg.DogstatsdURL != "":
 			// TODO: send merged metrics
 		}
+	} else {
+		// send metrics to black hole if we they aren't being configured.
+		m.cacheSink.SetSink(&metrics.BlackholeSink{})
+
 	}
 
 	return nil
@@ -254,12 +261,9 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 		if err != nil {
 			return err
 		}
-		conf := metrics.DefaultConfig("consul_dataplane")
-		conf.EnableHostname = false
-		_, err = metrics.NewGlobal(conf, sink)
-		if err != nil {
-			return err
-		}
+		// we set the cache sink to be the prometheus sink to
+		// replay out metrics recorded to the cache.
+		m.cacheSink.SetSink(sink)
 
 		go m.runCDPMetricsServer(r)
 
@@ -276,7 +280,7 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 
 // runCDPMetricsServer takes a prom.Gatherer that will create a handler
 // for http calls to the metrics endpoint and return prometheus style metrics.
-// Eventually these metrics will be
+// Eventually these metrics will be scraped and merged.
 func (m *metricsConfig) runCDPMetricsServer(gather prom.Gatherer) {
 	m.cdpMetricsServer = &http.Server{
 		Addr: cdpMetricsBindAddr,

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -66,6 +66,9 @@ type metricsConfig struct {
 }
 
 func NewMetricsConfig(cfg *Config, cacheSink *metricscache.Sink) *metricsConfig {
+	if cacheSink == nil {
+		cacheSink = metricscache.NewSink()
+	}
 	return &metricsConfig{
 		mu:                 sync.Mutex{},
 		cfg:                cfg.Telemetry,

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -242,7 +243,7 @@ func (m *metricsConfig) getPromDefaults() (*prom.Registry, *prometheus.Prometheu
 		Registerer:       reg,
 		GaugeDefinitions: gauges,
 		// CounterDefinitions: ,
-		// SummaryDefinitions: ,
+		SummaryDefinitions: discovery.Summaries,
 	}
 	return r, opts, nil
 }

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -244,7 +244,7 @@ func (m *metricsConfig) getPromDefaults() (*prom.Registry, *prometheus.Prometheu
 	}
 	opts := &prometheus.PrometheusOpts{
 		Registerer:       reg,
-		GaugeDefinitions: gauges,
+		GaugeDefinitions: append(gauges, discovery.Gauges...),
 		// CounterDefinitions: ,
 		SummaryDefinitions: discovery.Summaries,
 	}

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
+	metricscache "github.com/hashicorp/consul-dataplane/pkg/metrics-cache"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +35,7 @@ func TestMetricsServerClosed(t *testing.T) {
 		envoyAdminAddr:     envoyMetricsAddr,
 		envoyAdminBindPort: envoyMetricsPort,
 		errorExitCh:        make(chan struct{}),
+		cacheSink:          metricscache.NewSink(),
 
 		client: &http.Client{
 			Timeout: 10 * time.Second,
@@ -103,6 +105,7 @@ func TestMetricsServerEnabled(t *testing.T) {
 				envoyAdminAddr:     envoyMetricsAddr,
 				envoyAdminBindPort: envoyMetricsPort,
 				errorExitCh:        make(chan struct{}),
+				cacheSink:          metricscache.NewSink(),
 
 				client: &http.Client{
 					Timeout: 10 * time.Second,

--- a/pkg/consuldp/stats.go
+++ b/pkg/consuldp/stats.go
@@ -1,0 +1,10 @@
+package consuldp
+
+import "github.com/armon/go-metrics/prometheus"
+
+var gauges = []prometheus.GaugeDefinition{
+	{
+		Name: []string{"envoy_connected"},
+		Help: "This will either be 0 or 1 depending on whether Envoy is currently running and connected to the local xDS listeners.",
+	},
+}

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -122,14 +121,12 @@ func (p *Proxy) Run(ctx context.Context) error {
 		}
 		return err
 	}
-	metrics.SetGauge([]string{"envoy_connected"}, 1)
 
 	// This goroutine is responsible for waiting on the process (which reaps it
 	// preventing a zombie), triggering cleanup, and notifying the caller that the
 	// process has exited.
 	go func() {
 		err := p.cmd.Wait()
-		metrics.SetGauge([]string{"envoy_connected"}, 0)
 		p.cfg.Logger.Info("envoy process exited", "error", err)
 		p.transitionState(stateRunning, stateStopped)
 		if err := cleanup(); err != nil {

--- a/pkg/metrics-cache/metricscache.go
+++ b/pkg/metrics-cache/metricscache.go
@@ -28,12 +28,12 @@ type Sink struct {
 	realSink metrics.MetricSink
 
 	mu        sync.Mutex
-	checkLock atomic.Bool
+	checkLock *atomic.Bool
 }
 
 // NewSink returns a pointer to a sink with empty cache
 func NewSink() *Sink {
-	checkLock := atomic.Bool{}
+	checkLock := &atomic.Bool{}
 	checkLock.Store(true)
 
 	return &Sink{

--- a/pkg/metrics-cache/metricscache.go
+++ b/pkg/metrics-cache/metricscache.go
@@ -41,8 +41,8 @@ func NewSink() *Sink {
 		counters:  []metric{},
 		samples:   []metric{},
 		keys:      []metric{},
-		mu:        sync.Mutex{},
-		checkLock: checkLock, // we only need to check the lock if we haven't yet set the real sink
+		mu:        sync.Mutex{}, // this lock is used to control access around the slices of metrics above
+		checkLock: checkLock,    // we only need to check the lock if we haven't yet set the real sink
 	}
 }
 

--- a/pkg/metrics-cache/metricscache.go
+++ b/pkg/metrics-cache/metricscache.go
@@ -1,0 +1,156 @@
+package metricscache
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/armon/go-metrics"
+)
+
+var (
+	once sync.Once
+)
+
+type metric struct {
+	key    []string
+	val    float32
+	labels []metrics.Label
+}
+
+// Sink is a temporary sink that caches metrics until a real sink is set in SetSink.
+// it implements the metrics.MetricSink interface
+type Sink struct {
+	gauges   []metric
+	counters []metric
+	samples  []metric
+	keys     []metric
+
+	realSink metrics.MetricSink
+
+	mu        sync.Mutex
+	checkLock atomic.Bool
+}
+
+// NewSink returns a pointer to a sink with empty cache
+func NewSink() *Sink {
+	checkLock := atomic.Bool{}
+	checkLock.Store(true)
+
+	return &Sink{
+		gauges:    []metric{},
+		counters:  []metric{},
+		samples:   []metric{},
+		keys:      []metric{},
+		mu:        sync.Mutex{},
+		checkLock: checkLock, // we only need to check the lock if we haven't yet set the real sink
+	}
+}
+
+// SetGauge defaults to SetGaugeWithLabels
+func (s *Sink) SetGauge(key []string, val float32) {
+	s.SetGaugeWithLabels(key, val, nil)
+}
+
+// SetGaugeWithLabels sends metrics to the real sink otherwise caches them
+func (s *Sink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
+	if ok := s.checkLock.Load(); ok {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.SetGaugeWithLabels(key, val, labels)
+		return
+	}
+
+	s.gauges = append(s.gauges, metric{key: key, val: val, labels: labels})
+}
+
+// EmitKey sends metrics to the real sink otherwise caches them
+func (s *Sink) EmitKey(key []string, val float32) {
+	if ok := s.checkLock.Load(); ok {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.EmitKey(key, val)
+		return
+	}
+
+	s.keys = append(s.keys, metric{key: key, val: val})
+}
+
+// IncrCounter defaults to IncrCounterWithLabels
+func (s *Sink) IncrCounter(key []string, val float32) {
+	s.IncrCounterWithLabels(key, val, nil)
+
+}
+
+// IncrCounterWithLabels sends metrics to the real sink otherwise caches them
+func (s *Sink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {
+	if ok := s.checkLock.Load(); ok {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.IncrCounterWithLabels(key, val, labels)
+		return
+	}
+	s.counters = append(s.counters, metric{key: key, val: val, labels: labels})
+}
+
+// AddSample defaults to AddSampleWithLabels
+func (s *Sink) AddSample(key []string, val float32) {
+	s.AddSampleWithLabels(key, val, nil)
+}
+
+// AddSampleWithLabels sends metrics to the real sink otherwise caches them
+func (s *Sink) AddSampleWithLabels(key []string, val float32, labels []metrics.Label) {
+	if ok := s.checkLock.Load(); ok {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+	}
+
+	if s.realSink != nil {
+		s.realSink.AddSampleWithLabels(key, val, labels)
+		return
+	}
+	s.samples = append(s.samples, metric{key: key, val: val, labels: labels})
+}
+
+// SetSink takes a sink and will ensure that the sink sets the value
+// and then starts forwarding metrics on to the realSink once called.
+// It will also replay all the cached metrics and send the to the realSink
+func (s *Sink) SetSink(newSink metrics.MetricSink) {
+	once.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.checkLock.Store(false)
+		s.realSink = newSink
+		s.replay()
+	})
+}
+
+// replay will send cached metrics to the realsink. Once done it will empty the cached store.
+func (s *Sink) replay() {
+	if s.realSink != nil {
+		for _, sample := range s.samples {
+			s.realSink.AddSampleWithLabels(sample.key, sample.val, sample.labels)
+		}
+		s.samples = []metric{} // empty out after replaying samples
+		for _, gauge := range s.gauges {
+			s.realSink.SetGaugeWithLabels(gauge.key, gauge.val, gauge.labels)
+		}
+		s.gauges = []metric{} // empty out after replaying gauges
+		for _, counter := range s.counters {
+			s.realSink.IncrCounterWithLabels(counter.key, counter.val, counter.labels)
+		}
+		s.counters = []metric{} // empty out after replaying counters
+		for _, key := range s.keys {
+			s.realSink.EmitKey(key.key, key.val)
+		}
+		s.keys = []metric{} // empty out after replaying keys
+	}
+}

--- a/pkg/metrics-cache/metricscache.go
+++ b/pkg/metrics-cache/metricscache.go
@@ -7,10 +7,6 @@ import (
 	"github.com/armon/go-metrics"
 )
 
-var (
-	once sync.Once
-)
-
 type metric struct {
 	key    []string
 	val    float32
@@ -29,6 +25,7 @@ type Sink struct {
 
 	mu        sync.Mutex
 	checkLock *atomic.Bool
+	once      sync.Once
 }
 
 // NewSink returns a pointer to a sink with empty cache
@@ -124,7 +121,7 @@ func (s *Sink) AddSampleWithLabels(key []string, val float32, labels []metrics.L
 // and then starts forwarding metrics on to the realSink once called.
 // It will also replay all the cached metrics and send the to the realSink
 func (s *Sink) SetSink(newSink metrics.MetricSink) {
-	once.Do(func() {
+	s.once.Do(func() {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		s.checkLock.Store(false)

--- a/pkg/metrics-cache/metricscache.go
+++ b/pkg/metrics-cache/metricscache.go
@@ -119,7 +119,7 @@ func (s *Sink) AddSampleWithLabels(key []string, val float32, labels []metrics.L
 
 // SetSink takes a sink and will ensure that the sink sets the value
 // and then starts forwarding metrics on to the realSink once called.
-// It will also replay all the cached metrics and send the to the realSink
+// It will also replay all the cached metrics and send them to the realSink
 func (s *Sink) SetSink(newSink metrics.MetricSink) {
 	s.once.Do(func() {
 		s.mu.Lock()
@@ -130,7 +130,7 @@ func (s *Sink) SetSink(newSink metrics.MetricSink) {
 	})
 }
 
-// replay will send cached metrics to the realsink. Once done it will empty the cached store.
+// replay will send cached metrics to the realSink. Once done it will empty the cached store.
 func (s *Sink) replay() {
 	if s.realSink != nil {
 		for _, sample := range s.samples {

--- a/pkg/metrics-cache/metricscache_test.go
+++ b/pkg/metrics-cache/metricscache_test.go
@@ -62,7 +62,7 @@ func TestMetricsCache_BasicPath(t *testing.T) {
 func TestMetricsCache_ParallelTest(t *testing.T) {
 	sink := NewSink()
 	// make interval so big we never get metrics split into multiple intervals
-	realSink := metrics.NewInmemSink(time.Minute, time.Minute*10)
+	realSink := metrics.NewInmemSink(time.Second, time.Second)
 
 	wg := sync.WaitGroup{}
 	wg.Add(4)
@@ -105,8 +105,9 @@ func TestMetricsCache_ParallelTest(t *testing.T) {
 	mysamples := data[0].Samples["mysample"]
 	mykey := data[0].Points["mykey"]
 	mycounter := data[0].Counters["mycounter"]
-	require.EqualValues(t, 100, mygauge.Value)
 	require.EqualValues(t, 100, mysamples.AggregateSample.Count)
+	require.EqualValues(t, 100, mygauge.Value)
+
 	require.EqualValues(t, 100, len(mykey))
 	require.EqualValues(t, 100, mycounter.AggregateSample.Count)
 

--- a/pkg/metrics-cache/metricscache_test.go
+++ b/pkg/metrics-cache/metricscache_test.go
@@ -1,0 +1,113 @@
+package metricscache
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsCache_BasicPath(t *testing.T) {
+	sink := NewSink()
+
+	sink.SetGauge([]string{"mygauge"}, 1)
+	sink.AddSample([]string{"mysample"}, 10)
+	sink.AddSample([]string{"mysample"}, 100)
+	sink.EmitKey([]string{"mykey"}, 3)
+	sink.IncrCounter([]string{"mycounter"}, 4)
+	sink.IncrCounter([]string{"mycounter"}, 8)
+	sink.IncrCounter([]string{"mycounter"}, 16)
+
+	realSink := metrics.NewInmemSink(time.Second, time.Second*1)
+	sink.SetSink(realSink)
+	sink.IncrCounter([]string{"mycounter"}, 32)
+
+	data := realSink.Data()
+
+	// Check before the interval is up if setting values will increase the metrics
+
+	mygauge := data[0].Gauges["mygauge"]
+	require.EqualValues(t, mygauge.Value, 1)
+
+	// Samples based off setting twice: once at 10, once at 110
+	mysamples := data[0].Samples["mysample"]
+	require.EqualValues(t, 2, mysamples.AggregateSample.Count)
+	require.EqualValues(t, 110, mysamples.AggregateSample.Sum)
+	require.EqualValues(t, 10, mysamples.AggregateSample.Min)
+	require.EqualValues(t, 100, mysamples.AggregateSample.Max)
+
+	// Keys based off a single value of 3
+	mykey := data[0].Points["mykey"]
+	require.EqualValues(t, mykey[0], 3)
+
+	// counter's based off being set four times with values 4, 8, 16, 32
+	mycounter := data[0].Counters["mycounter"]
+	require.EqualValues(t, 4, mycounter.AggregateSample.Count)
+	require.EqualValues(t, 60, mycounter.AggregateSample.Sum)
+	require.EqualValues(t, 4, mycounter.AggregateSample.Min)
+	require.EqualValues(t, 32, mycounter.AggregateSample.Max)
+
+	sink.IncrCounter([]string{"mycounter"}, 2)
+	data = realSink.Data()
+	mycounter = data[0].Counters["mycounter"]
+	require.EqualValues(t, 5, mycounter.AggregateSample.Count)
+	require.EqualValues(t, 62, mycounter.AggregateSample.Sum)
+	require.EqualValues(t, 2, mycounter.AggregateSample.Min)
+	require.EqualValues(t, 32, mycounter.AggregateSample.Max)
+
+}
+
+func TestMetricsCache_ParallelTest(t *testing.T) {
+	sink := NewSink()
+	// make interval so big we never get metrics split into multiple intervals
+	realSink := metrics.NewInmemSink(time.Minute, time.Minute*10)
+
+	wg := sync.WaitGroup{}
+	wg.Add(4)
+	go func() {
+		for i := 0; i < 100; i++ {
+			sink.SetGauge([]string{"mygauge"}, float32(i+1))
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			sink.AddSample([]string{"mysample"}, 1)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			sink.EmitKey([]string{"mykey"}, 1)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			sink.IncrCounter([]string{"mycounter"}, 1)
+		}
+		wg.Done()
+	}()
+
+	sink.SetSink(realSink)
+	wg.Wait()
+
+	data := realSink.Data()
+
+	require.NotEmpty(t, data)
+
+	mygauge := data[0].Gauges["mygauge"]
+	mysamples := data[0].Samples["mysample"]
+	mykey := data[0].Points["mykey"]
+	mycounter := data[0].Counters["mycounter"]
+	require.EqualValues(t, 100, mygauge.Value)
+	require.EqualValues(t, 100, mysamples.AggregateSample.Count)
+	require.EqualValues(t, 100, len(mykey))
+	require.EqualValues(t, 100, mycounter.AggregateSample.Count)
+
+}


### PR DESCRIPTION
This is dependent on this [changeset](https://github.com/hashicorp/consul-server-connection-manager/pull/16) being merged first and then re running a `go get github.com/hashicorp/consul-server-connection-manager/discovery` 


After the above this PR is best viewed commit by commit: 

1. a4bff1309bb8dffb527cfc661332c59c569f1b1a Adds in a metrics-cache sink. This is necessary because we need to start recording metrics before we know if the envoy configuration actually specified exporting metrics. This cache sink will store metrics until we have configured the metricsConfig and then it will forward all the metrics to the configured sink (be that a blackhole if not configured or a prometheus sink if configured). 
2. efcd49304aee0564a496c4b8f833ab3a3031e757 this commit adds in the metrics-cache defined in 1. into the consul-dataplane and ensures we start recording metrics before we ever setup the real metrics sink.
3. 54525d0b25ed71e4d42f909a6c646e151d8b96e1 this change set defines a prometheus definition for the envoy_connected metrics and adds it to the prometheus opts
4. a1f007904d1a20c8ecd3b537f1e8e82f2cb5a9c2 this fetches the changeset above so we can add the exported summary definitions to the prometheus opts for the consul-dataplane metrics. 
5. e6b1dde6d488a7b053464db503fe0d784ad31b43 fixes some linting errors. 
6. f09943aabef839867513900f801c595aa63d11ef adds some commenting
7. 6a42c90fca2448720777414e5cfce76e1ce1d57b is fixing some tests and adding go 1.19

We are still missing the following metrics defined in the RFC but we can add them as the functionality becomes available: 
- consul_dataplane.roots_updates - This will be a counter of the number of roots updates received.
- consul_dataplane.certificate_create_duration - This will be a sample of the time spent getting a new certificate created. It includes both the time spent doing local cryptography as well as the gRPC call to the servers to sign the certificate.
- consul_dataplane.certificate_create_errors - This will be a counter that increases when an error is encountered. The most likely of these would be when that RPC is getting rate limited.
- consul_dataplane.certificate_expiration_minutes - This will be the number of minutes until the certificate will expire. This will be particularly useful in validating that certificate renewal is happening as desired and that the underlying mesh enabled service should be able to continue operating.

