### PR TITLE
Adding statsD and dogstatsD support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/DataDog/datadog-go v3.2.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a h1:8fjfNnk9RLn3F4R4XEljSOZARy1+h1f0KTh6xGFefjw=
 github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a/go.mod h1:Aku9EjGILrB1V88F+yfJ8CaIVaKqDeWkW2vkCbY2WSA=

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -45,9 +45,8 @@ func assertServerMatchesExpected(t *testing.T, server *net.UDPConn, buf []byte, 
 	n, _ := server.Read(buf)
 	msg := string(buf[:n])
 
-	if msg != expected {
-		t.Fatalf("Line %s does not match expected: %s", msg, expected)
-	}
+	require.Equal(t, msg, expected, fmt.Sprintf("Line %s does not match expected: %s", msg, expected))
+
 }
 
 func TestMetricsServerClosed(t *testing.T) {

--- a/pkg/consuldp/xds.go
+++ b/pkg/consuldp/xds.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/adamthesax/grpc-proxy/proxy"
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -113,13 +112,12 @@ func (cdp *ConsulDataplane) xdsServerExited() chan struct{} { return cdp.xdsServ
 
 func (cdp *ConsulDataplane) streamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		return handler(srv, &metricServerStream{ss, cdp.logger}) // blocking if connected so envoy not connecting will end up being quite spiky
+		return handler(srv, &metricServerStream{ss})
 	}
 }
 
 type metricServerStream struct {
 	grpc.ServerStream
-	logger hclog.Logger
 }
 
 func (s *metricServerStream) SendMsg(m interface{}) error {


### PR DESCRIPTION
This PR is best viewed commit by commit. 

1. e7347d3c9ff829180a6b72c2b3984e9652075c0a adds support for statsD and dogstatsD if the envoy proxy is configured with dogstatsD or statsD and configure's the consul dataplane metrics to sink to statsD or dogtstatsD. This approach means we leave it up envoy  to push it's own metrics statsD/dogstatsD and we push our own metrics as well. service metrics would have to also push to statsD itself (not sure of this so have to sync with @pglass)
2. 7d712cdbd36fdc4ec126195c3c4da41fe48b4e7d cleaning up the logger in the stream interceptor that was used only for testing 
3. b1104c1498fd46c9a2383ce5cb8561dc6864372b was to rename functions to hopefully be a bit more clear on the purpose. 