### PR TITLE
Add telemetry-prom-merge-port flag for merged metrics

### DIFF
--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -55,6 +55,7 @@ var (
 	promCertFile          string
 	promServiceMetricsURL string
 	promScrapePath        string
+	promMergePort         int
 
 	adminBindAddr    string
 	adminBindPort    int
@@ -112,6 +113,7 @@ func init() {
 	flag.StringVar(&promCertFile, "telemetry-prom-cert-file", "", "The path to the client certificate used to serve Prometheus metrics.")
 	flag.StringVar(&promServiceMetricsURL, "telemetry-prom-service-metrics-url", "", "Prometheus metrics at this URL are scraped and included in Consul Dataplane's main Prometheus metrics.")
 	flag.StringVar(&promScrapePath, "telemetry-prom-scrape-path", "", "The URL path where Envoy serves Prometheus metrics.")
+	flag.IntVar(&promMergePort, "telemetry-prom-merge-port", 20100, "The port to serve merged Prometheus metrics.")
 
 	flag.StringVar(&adminBindAddr, "envoy-admin-bind-address", "127.0.0.1", "The address on which the Envoy admin server is available.")
 	flag.IntVar(&adminBindPort, "envoy-admin-bind-port", 19000, "The port on which the Envoy admin server is available.")
@@ -204,6 +206,7 @@ func main() {
 				CertFile:          promCertFile,
 				ServiceMetricsURL: promServiceMetricsURL,
 				ScrapePath:        promScrapePath,
+				MergePort:         promMergePort,
 			},
 		},
 		Envoy: &consuldp.EnvoyConfig{

--- a/internal/bootstrap/bootstrap_tpl.go
+++ b/internal/bootstrap/bootstrap_tpl.go
@@ -112,10 +112,21 @@ type BootstrapTplArgs struct {
 	// the envoy_prometheus_bind_addr listener.
 	PrometheusScrapePath string
 
-	PrometheusCAFile   string
-	PrometheusCAPath   string
+	// PrometheusCAFile is the path to a CA file for Envoy to use when serving TLS on the Prometheius metrics
+	// endpoint. Only applicable when envoy_prometheus_bind_addr is set in the proxy config.
+	PrometheusCAFile string
+
+	// PrometheusCAPath is the path to a directory of CA certificates for Envoy to use when serving the Prometheus
+	// metrics endpoint. Only applicable when envoy_prometheus_bind_addr is set in the proxy config.
+	PrometheusCAPath string
+
+	// PrometheusCertFile is the path to a certificate file for Envoy to use when serving TLS on the Prometheus
+	// metrics endpoint. Only applicable when envoy_prometheus_bind_addr is set in the proxy config.
 	PrometheusCertFile string
-	PrometheusKeyFile  string
+
+	// PrometheusKeyFile is the path to a private key file Envoy to use when service TLS on the Prometheus metrics
+	// endpoint. Only applicable when envoy_prometheus_bind_addr is set in the proxy config.
+	PrometheusKeyFile string
 }
 
 // GRPC settings used in the bootstrap template.

--- a/internal/bootstrap/bootstrap_tpl.go
+++ b/internal/bootstrap/bootstrap_tpl.go
@@ -124,7 +124,7 @@ type BootstrapTplArgs struct {
 	// metrics endpoint. Only applicable when envoy_prometheus_bind_addr is set in the proxy config.
 	PrometheusCertFile string
 
-	// PrometheusKeyFile is the path to a private key file Envoy to use when service TLS on the Prometheus metrics
+	// PrometheusKeyFile is the path to a private key file Envoy to use when serving TLS on the Prometheus metrics
 	// endpoint. Only applicable when envoy_prometheus_bind_addr is set in the proxy config.
 	PrometheusKeyFile string
 }

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -108,7 +108,7 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 		// Envoy proxy metrics from Consul Dataplane which serves merged
 		// metrics (Envoy + Dataplane + service metrics).
 		// Documentation: https://www.consul.io/commands/connect/envoy#prometheus-backend-port
-		args.PrometheusBackendPort = mergedMetricsBackendBindPort
+		args.PrometheusBackendPort = strconv.Itoa(prom.MergePort)
 	}
 
 	// Note: we pass true for omitDeprecatedTags here - consul-dataplane is clean

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -98,6 +98,7 @@ func TestBootstrapConfig(t *testing.T) {
 				Telemetry: &TelemetryConfig{
 					UseCentralConfig: true,
 					Prometheus: PrometheusTelemetryConfig{
+						MergePort:  20100,
 						ScrapePath: "/custom/scrape/path",
 					},
 				},

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -254,6 +254,8 @@ type PrometheusTelemetryConfig struct {
 	ServiceMetricsURL string
 	// ScrapePath is the URL path where Envoy serves Prometheus metrics.
 	ScrapePath string
+	// MergePort is the port to server merged metrics.
+	MergePort int
 }
 
 // EnvoyConfig contains configuration for the Envoy process.

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -26,9 +27,9 @@ type Stats int
 const (
 	// mergedMetricsBackendBindPort is the port which will serve the merged
 	// metrics. The envoy bootstrap config uses this port to setup the publicly
-	// available scarpe url that prometheus listener which will point to this port
-	mergedMetricsBackendBindPort = "20100"
-	mergedMetricsBackendBindAddr = "127.0.0.1:" + mergedMetricsBackendBindPort
+	// available scrape url that prometheus listener which will point to this port
+	defaultMergedMetricsBackendBindPort = "20100"
+	mergedMetricsBackendBindHost        = "127.0.0.1:"
 
 	// The consul dataplane specific metrics will be exposed on this port on the loopback
 	cdpMetricsBindPort = "20101"
@@ -100,25 +101,31 @@ func (m *metricsConfig) startMetrics(ctx context.Context, bcfg *bootstrap.Bootst
 
 		switch {
 		case bcfg.PrometheusBindAddr != "":
-			// 1. start consul dataplane metric sinks of type Prometheus
+			// 1. start consul dataplane metric sinks of type Prometheus.
 			err := m.configureCDPMetricSinks(Prometheus)
 			if err != nil {
 				return fmt.Errorf("failure enabling consul dataplane metrics for prometheus: %w", err)
 			}
 
 			// 2. Setup prometheus handler for the merged metrics endpoint that prometheus
-			// will actually scrape
+			// will actually scrape.
 			mux := http.NewServeMux()
 			mux.HandleFunc("/stats/prometheus", m.mergedMetricsHandler)
 			m.urls = []string{cdpMetricsUrl, fmt.Sprintf("http://%s:%v/stats/prometheus", m.envoyAdminAddr, m.envoyAdminBindPort)}
 			if m.cfg != nil && m.cfg.Prometheus.ServiceMetricsURL != "" {
 				m.urls = append(m.urls, m.cfg.Prometheus.ServiceMetricsURL)
 			}
+
+			// 3. Determine what the merged metrics bind port is. It can be set as a flag.
+			mergedMetricsBackendBindPort := defaultMergedMetricsBackendBindPort
+			if m.cfg.Prometheus.MergePort != 0 {
+				mergedMetricsBackendBindPort = strconv.Itoa(m.cfg.Prometheus.MergePort)
+			}
 			m.promScrapeServer = &http.Server{
-				Addr:    mergedMetricsBackendBindAddr,
+				Addr:    mergedMetricsBackendBindHost + mergedMetricsBackendBindPort,
 				Handler: mux,
 			}
-			// Start prometheus metrics sink
+			// 4. Start prometheus metrics sink
 			go m.startPrometheusMetricsSink()
 
 		case bcfg.StatsdURL != "":

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -54,6 +54,7 @@ func TestMetricsServerClosed(t *testing.T) {
 }
 
 func TestMetricsServerEnabled(t *testing.T) {
+	mergedMetricsBackendBindAddr := mergedMetricsBackendBindHost + defaultMergedMetricsBackendBindPort
 	cases := map[string]struct {
 		telemetry  *TelemetryConfig
 		expMetrics []string


### PR DESCRIPTION
This PR adds a new flag to consul-dataplane named `telemetry-prom-merge-port` with a default value of `20100`. This is in order to support merged metrics with consul-k8s. The PR is paired with the consul-k8s PR [Merged metrics with consul-dataplane](https://github.com/hashicorp/consul-k8s/pull/1635) and this PR should be merged before consul-k8s one.

I have mainly tested the merged metrics through the consul-k8s acceptance tests and they are passing. The acceptance tests test: 
- component metrics - that you can get metrics out of the server and agent. Agent is still there as there is a chance that customers will still run agents.
- gateways - ingress, terminating and mesh are serving metrics.
- app - that an app can run and it's metrics are served.