### PR TITLE
Pinning hashicorp/actions-go-build to v0.1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: hashicorp/actions-go-build@v0
+      - uses: hashicorp/actions-go-build@v0.1.4
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.get-product-version.outputs.product-version }}
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: hashicorp/actions-go-build@v0
+      - uses: hashicorp/actions-go-build@v0.1.4
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.get-product-version.outputs.product-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: hashicorp/actions-go-build@v0.1.4
+      - uses: hashicorp/actions-go-build@v0.1.3
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.get-product-version.outputs.product-version }}
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: hashicorp/actions-go-build@v0.1.4
+      - uses: hashicorp/actions-go-build@v0.1.3
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.get-product-version.outputs.product-version }}


### PR DESCRIPTION
The latest actions-go-build v0.1.6 is failing to build with go 1.19.  This is an attempt to get it working again.

Note: Github Actions always pull from main so the builds will fail until this is merged.