### PR TITLE
Adding fanout sink for dogstatsd/statsd/prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
-	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17
+	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221021152734-b0e0a3f762e8
 	github.com/hashicorp/consul/proto-public v0.1.1
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
-	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415
+	github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17
 	github.com/hashicorp/consul/proto-public v0.1.1
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,14 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415 h1:NZnQy0p2YjL9L+tsFqHWs4MubbDxCi4aJEFOI0uvaTo=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019033606-ec980d48ec87 h1:cZ28cSkR03udtjCTCzkq7MUG4mRR2/iNc0liQZqh5bM=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019033606-ec980d48ec87/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034147-2c35067f37c7 h1:ttX0OM4nnQWDQ1TF0VHd6fZ1CIl8Tx//Kp+LWbBTtw0=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034147-2c35067f37c7/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034955-97bf56c8639c h1:mOl4Fm1hLSZTC0WIiKCGvAgEN3LR8dpiNfTE1lrnD0w=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034955-97bf56c8639c/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17 h1:TrH2uVDXHg2nUNsBDh9GGrf7BqA+SpBp2sy2KZrfQI8=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=
 github.com/hashicorp/consul/proto-public v0.1.1/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=

--- a/go.sum
+++ b/go.sum
@@ -149,16 +149,6 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415 h1:NZnQy0p2YjL9L+tsFqHWs4MubbDxCi4aJEFOI0uvaTo=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221014171920-1e2af7207415/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019033606-ec980d48ec87 h1:cZ28cSkR03udtjCTCzkq7MUG4mRR2/iNc0liQZqh5bM=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019033606-ec980d48ec87/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034147-2c35067f37c7 h1:ttX0OM4nnQWDQ1TF0VHd6fZ1CIl8Tx//Kp+LWbBTtw0=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034147-2c35067f37c7/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034955-97bf56c8639c h1:mOl4Fm1hLSZTC0WIiKCGvAgEN3LR8dpiNfTE1lrnD0w=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034955-97bf56c8639c/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17 h1:TrH2uVDXHg2nUNsBDh9GGrf7BqA+SpBp2sy2KZrfQI8=
-github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221021152734-b0e0a3f762e8 h1:7mpoEG0ITDsHo5eaqqGSo+1rKuYHhxiDUmq4RC5YB5I=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221021152734-b0e0a3f762e8/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034955-97bf
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019034955-97bf56c8639c/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17 h1:TrH2uVDXHg2nUNsBDh9GGrf7BqA+SpBp2sy2KZrfQI8=
 github.com/hashicorp/consul-server-connection-manager v0.0.0-20221019035424-92b8d7c2ce17/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221021152734-b0e0a3f762e8 h1:7mpoEG0ITDsHo5eaqqGSo+1rKuYHhxiDUmq4RC5YB5I=
+github.com/hashicorp/consul-server-connection-manager v0.0.0-20221021152734-b0e0a3f762e8/go.mod h1:M4QVHe3V96rwbf1HHYQlEe6XGagLENeh+r8BhcVL4jA=
 github.com/hashicorp/consul/proto-public v0.1.1 h1:C28d6xX+DwoD2dSex/kwD0/nJ4XNgoBtQXtZEm4FGEk=
 github.com/hashicorp/consul/proto-public v0.1.1/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
@@ -261,10 +262,10 @@ func non2xxCode(code int) bool {
 func (m *metricsConfig) getPromDefaults() (*prom.Registry, *prometheus.PrometheusOpts, error) {
 	r := prom.NewRegistry()
 	reg := prom.WrapRegistererWithPrefix("consul_dataplane_", r)
-	// err := reg.Register(collectors.NewGoCollector())
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
+	err := reg.Register(collectors.NewGoCollector())
+	if err != nil {
+		return nil, nil, err
+	}
 	opts := &prometheus.PrometheusOpts{
 		Registerer:       reg,
 		GaugeDefinitions: append(gauges, discovery.Gauges...),

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -148,6 +148,7 @@ func (m *metricsConfig) startMetrics(ctx context.Context, bcfg *bootstrap.Bootst
 				return fmt.Errorf("failure enabling consul dataplane metrics for dogstatsD: %w", err)
 			}
 		}
+		// Set the cache sink with the fanout sinks which will trigger a replay to all of the children sinks
 		m.cacheSink.SetSink(m.sinks)
 	} else {
 		// send metrics to black hole if they aren't being configured.
@@ -288,8 +289,7 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 		if err != nil {
 			return err
 		}
-		// we set the cache sink to be the prometheus sink to
-		// replay out metrics recorded to the cache.
+		// Append the prometheus sink to the fanout sink
 		m.sinks = append(m.sinks, sink)
 
 		go m.runPrometheusCDPServer(r)
@@ -298,6 +298,7 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 		if err != nil {
 			return err
 		}
+		// Append the statsd sink to the fanout sink
 		m.sinks = append(m.sinks, sink)
 	case Dogstatsd:
 
@@ -306,6 +307,7 @@ func (m *metricsConfig) configureCDPMetricSinks(s Stats) error {
 			return err
 		}
 		sink.SetTags(m.dogstatsTags)
+		// Append the dogstatsd sink to the fanout sink
 		m.sinks = append(m.sinks, sink)
 	}
 	return nil

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -344,3 +344,22 @@ func (m *metricsConfig) runPrometheusCDPServer(gather prom.Gatherer) {
 		close(m.errorExitCh)
 	}
 }
+
+func parseSinkAddr(addr string, s Stats) (string, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse address %s", addr)
+	}
+	var address string
+	switch {
+	case s == Prometheus:
+		return "", fmt.Errorf("prometheus not implemented")
+	case u.Scheme == "udp":
+		address = fmt.Sprintf("%s:%s", u.Hostname(), u.Port())
+	case u.Scheme == "unix" && s == Dogstatsd:
+		address = addr
+	default:
+		return "", fmt.Errorf("unsupported addr: %s for sink type: %s", addr, s)
+	}
+	return address, nil
+}

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -25,6 +25,19 @@ import (
 
 type Stats int
 
+func (s Stats) String() string {
+	switch s {
+	case Prometheus:
+		return "prometheus"
+	case Dogstatsd:
+		return "dogstatsD"
+	case Statsd:
+		return "statsD"
+	default:
+		return "default"
+	}
+}
+
 const (
 	// mergedMetricsBackendBindPort is the port which will serve the merged
 	// metrics. The envoy bootstrap config uses this port to setup the publicly

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -274,7 +274,8 @@ func TestMetricsStatsD(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_ = m.startMetrics(ctx, &bootstrap.BootstrapConfig{StatsdURL: fmt.Sprintf("%v:%v", dogStatsdAddr, port)})
+	err := m.startMetrics(ctx, &bootstrap.BootstrapConfig{StatsdURL: fmt.Sprintf("udp://%v:%v", dogStatsdAddr, port)})
+	require.NoError(t, err)
 
 	for _, tt := range testMetrics {
 		t.Run(tt.Method, func(t *testing.T) {
@@ -340,8 +341,8 @@ func TestMetricsDatadogWithoutGlobalTags(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_ = m.startMetrics(ctx, &bootstrap.BootstrapConfig{DogstatsdURL: fmt.Sprintf("%v:%v", dogStatsdAddr, port)})
-
+	err := m.startMetrics(ctx, &bootstrap.BootstrapConfig{DogstatsdURL: fmt.Sprintf("udp://%v:%v", dogStatsdAddr, port)})
+	require.NoError(t, err)
 	for _, tt := range testMetrics {
 		t.Run(tt.Method, func(t *testing.T) {
 			switch tt.Method {
@@ -407,8 +408,8 @@ func TestMetricsDatadogWithGlobalTags(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_ = m.startMetrics(ctx, &bootstrap.BootstrapConfig{DogstatsdURL: fmt.Sprintf("%v:%v", dogStatsdAddr, port), StatsTags: []string{globalTags}})
-
+	err := m.startMetrics(ctx, &bootstrap.BootstrapConfig{DogstatsdURL: fmt.Sprintf("udp://%v:%v", dogStatsdAddr, port), StatsTags: []string{globalTags}})
+	require.NoError(t, err)
 	for _, tt := range testMetrics {
 		t.Run(tt.Method, func(t *testing.T) {
 			switch tt.Method {


### PR DESCRIPTION
Allowing users to specify multiple types of sinks and upgrading consul-server-connection-manager