### PR TITLE
Set prometheus retention time

### DIFF
--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -144,6 +144,10 @@ func validateFlags() {
 	default:
 		log.Fatal("invalid log level. valid values - TRACE, DEBUG, INFO, WARN, ERROR")
 	}
+
+	if promRetentionTime <= 0 {
+		log.Fatal("Prometheus retention time must be greater than 0")
+	}
 }
 
 func main() {

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/consul-dataplane/pkg/consuldp"
 	"github.com/hashicorp/consul-dataplane/pkg/version"
@@ -49,7 +50,7 @@ var (
 
 	useCentralTelemetryConfig bool
 
-	promRetentionTime     string
+	promRetentionTime     time.Duration
 	promCACertsPath       string
 	promKeyFile           string
 	promCertFile          string
@@ -107,7 +108,7 @@ func init() {
 
 	flag.BoolVar(&useCentralTelemetryConfig, "telemetry-use-central-config", true, "Controls whether the proxy applies the central telemetry configuration.")
 
-	flag.StringVar(&promRetentionTime, "telemetry-prom-retention-time", "", "The duration for Prometheus metrics aggregation.")
+	flag.DurationVar(&promRetentionTime, "telemetry-prom-retention-time", 60*time.Second, "The duration for Prometheus metrics aggregation.")
 	flag.StringVar(&promCACertsPath, "telemetry-prom-ca-certs-path", "", "The path to a file or directory containing CA certificates used to verify the Prometheus server's certificate.")
 	flag.StringVar(&promKeyFile, "telemetry-prom-key-file", "", "The path to the client private key used to serve Prometheus metrics.")
 	flag.StringVar(&promCertFile, "telemetry-prom-cert-file", "", "The path to the client certificate used to serve Prometheus metrics.")

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
 	"github.com/hashicorp/go-rootcerts"
@@ -236,7 +237,7 @@ type TelemetryConfig struct {
 // PrometheusTelemetryConfig contains Prometheus-specific telemetry config.
 type PrometheusTelemetryConfig struct {
 	// RetentionTime controls the duration that metrics are aggregated for.
-	RetentionTime string
+	RetentionTime time.Duration
 	// CACertsPath is a path to a file or directory containing CA certificates
 	// to use to verify the Prometheus server's certificate. This is only
 	// necessary if the server presents a certificate that isn't signed by a

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -2,6 +2,7 @@ package consuldp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func validConfig() *Config {
 		Telemetry: &TelemetryConfig{
 			UseCentralConfig: true,
 			Prometheus: PrometheusTelemetryConfig{
-				RetentionTime:     "30s",
+				RetentionTime:     30 * time.Second,
 				CACertsPath:       "/tmp/my-certs/",
 				KeyFile:           "/tmp/my-key.pem",
 				CertFile:          "/tmp/my-cert.pem",

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -266,6 +266,7 @@ func (m *metricsConfig) getPromDefaults() (*prom.Registry, *prometheus.Prometheu
 		return nil, nil, err
 	}
 	opts := &prometheus.PrometheusOpts{
+		Expiration:       m.cfg.Prometheus.RetentionTime,
 		Registerer:       reg,
 		GaugeDefinitions: append(gauges, discovery.Gauges...),
 		// CounterDefinitions: ,


### PR DESCRIPTION
This is a fix to pass the `-telemetry-prom-retention-time` value through to the Prometheus sink.