### PR TITLE
integration-tests: fix timing-related flake

### DIFF
--- a/integration-tests/helpers/server.go
+++ b/integration-tests/helpers/server.go
@@ -80,7 +80,7 @@ func RunServer(t *testing.T, suite *Suite) *ConsulServer {
 			testcontainers.VolumeMount(volume.Name, "/data"),
 		},
 		ExposedPorts: []string{string(serverHTTPPort)},
-		WaitingFor:   wait.ForLog("New leader elected"),
+		WaitingFor:   wait.ForLog("successfully established leadership"),
 		Cmd:          []string{"consul", "agent", "-config-file", "/data/server.hcl", "-client", "0.0.0.0"},
 	})
 


### PR DESCRIPTION
Fixes a timing-related flake in the integration tests, where we were previously waiting for the server to become the leader from Raft's POV but not for it to finish initializing ACLs etc. Which meant that we'd occasionally see an "ACL not found" error.
