### PR TITLE
Dockerfile: bump up UBI base image to 9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
 # This image is based on the Red Hat UBI base image, and has the necessary
 # labels, license file, and non-root user.
 # -----------------------------------
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as release-ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:9.1.0 as release-ubi
 
 ARG BIN_NAME
 ENV BIN_NAME=$BIN_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
 # This image is based on the Red Hat UBI base image, and has the necessary
 # labels, license file, and non-root user.
 # -----------------------------------
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as release-ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as release-ubi
 
 ARG BIN_NAME
 ENV BIN_NAME=$BIN_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
 # This image is based on the Red Hat UBI base image, and has the necessary
 # labels, license file, and non-root user.
 # -----------------------------------
-FROM registry.access.redhat.com/ubi8/ubi-minimal:9.1.0 as release-ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.1.0 as release-ubi
 
 ARG BIN_NAME
 ENV BIN_NAME=$BIN_NAME


### PR DESCRIPTION
Latest UBI base image is now 9.1: https://catalog.redhat.com/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d?push_date=1668533737000&architecture=amd64&container-tabs=overview