### PR TITLE
JIRA: JIRA PR Fix

### DIFF
--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -58,7 +58,8 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve)
           extraFields: '{ "customfield_10089": "${{ github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },            
+                          "customfield_10371": { "value": "GitHub" },
+                          "customfield_10535": [{ "value": "Service Mesh" }],
                           "components": [{ "name": "${{ github.event.repository.name }}" }],
                           "labels": ${{ steps.set-ticket-labels.outputs.LABELS }} }'
         env:


### PR DESCRIPTION
Currently an error when community PRs are filed pop up due to the default Workstream custom field not being populated.