### PR TITLE
chore(ci): update dev builds to v1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,8 @@ jobs:
             image: docker.mirror.hashicorp.services/hashicorp/consul:1.14.4
           - version: v1.15.0-dev
             image: hashicorppreview/consul:1.15-dev
+          - version: v1.16.0-dev
+            image: hashicorppreview/consul:1.16-dev
         dataplane:
           - image_suffix: "dev"
             docker_target: "release-default"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.1.0"
+	Version = "1.2.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
`release/1.1.x` branch is cut. This moves `main` to build `1.2.0` dev images.