### PR TITLE
chore(ci): add bot auto-approve for backport PRs

### DIFF
--- a/.github/workflows/bot-auto-approve.yaml
+++ b/.github/workflows/bot-auto-approve.yaml
@@ -1,0 +1,13 @@
+name: Bot Auto Approve
+
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.actor == 'hc-github-team-consul-core'
+    steps:
+      - uses: hmarr/auto-approve-action@v3
+        with:
+          review-message: "Auto approved Consul Bot automated PR"
+          github-token: ${{ secrets.MERGE_APPROVE_TOKEN }}


### PR DESCRIPTION
## Description

This adds auto-approvals for backport PRs. Approval from a user that is not the author of the PR (`hc-github-team-consul-core` for backports) is required for GitHub automerge to complete.

I will add the `MERGE_APPROVE_TOKEN` to the repo.