### PR TITLE
security: update Envoy to 1.24.7

### DIFF
--- a/.changelog/99.txt
+++ b/.changelog/99.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update to Go 1.20.4 and Envoy 1.24.7 within the Dockerfile. 
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - id: run-tests
         run: cd integration-tests && go test -v -output-dir=./output -dataplane-image=hashicorppreview/${{env.repo}}:${{env.dev_tag}}-${{github.sha}} -server-image=${{matrix.server.image}}
         continue-on-error: true

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -3,7 +3,7 @@ name: consul-dataplane-checks
 on:
   push:
     branches:
-      main
+    - main
   pull_request:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - run: go test ./...
   golangci:
     name: lint
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@
 
 # envoy-binary pulls in the latest Envoy binary, as Envoy don't publish
 # prebuilt binaries in any other form.
-FROM envoyproxy/envoy-distroless:v1.24.1 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.24.7 as envoy-binary
 
 # go-discover builds the discover binary (which we don't currently publish
 # either).
-FROM golang:1.19.4-alpine as go-discover
+FROM golang:1.20.4-alpine as go-discover
 RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@49f60c093101c9c5f6b04d5b1c80164251a761a6
 
 # Pull in dumb-init from alpine, as our distroless release image doesn't have a

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-dataplane/integration-tests
 
-go 1.19
+go 1.20
 
 require (
 	github.com/docker/docker v20.10.17+incompatible


### PR DESCRIPTION
Updating the 1.1.x release branch with the latest patch of Envoy. The Golang version is also updated according to the existing root .go-version file.