### PR TITLE
fix: set initial_fetch_timeout to wait for initial xDS…

### DIFF
--- a/.changelog/104.txt
+++ b/.changelog/104.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix bug with Envoy starting with partial configuration by wait indefinitely for complete, initial xDS configuration.
+```

--- a/.changelog/104.txt
+++ b/.changelog/104.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Fix bug with Envoy starting with partial configuration by wait indefinitely for complete, initial xDS configuration.
+Fix a bug with Envoy potentially starting with incomplete configuration by not waiting enough for initial xDS configuration.
 ```

--- a/internal/bootstrap/bootstrap_tpl.go
+++ b/internal/bootstrap/bootstrap_tpl.go
@@ -282,10 +282,12 @@ const bootstrapTemplate = `{
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+	  "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+	  "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/access-logs.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/access-logs.golden
@@ -157,10 +157,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/basic.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/basic.golden
@@ -145,10 +145,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/central-telemetry-config.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/central-telemetry-config.golden
@@ -159,10 +159,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
@@ -234,10 +234,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
@@ -182,10 +182,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/ready-listener.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/ready-listener.golden
@@ -234,10 +234,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/unix-socket-xds-server.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/unix-socket-xds-server.golden
@@ -144,10 +144,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {


### PR DESCRIPTION
### Description

Consul dataplane updates for [#17283.](https://github.com/hashicorp/consul/issues/17283).

This changes the time Envoy waits for the initial xDS configuration from the default (15s) to indefinitely. This prevents Envoy from starting with only a partial list of listeners/clusters.

### Testing & Reproduction steps

Goldenfile tests have been updated since this affects Envoy's bootstrap configuration.
