### PR TITLE
Remove HCP naming references for collector metrics

### DIFF
--- a/.changelog/112.txt
+++ b/.changelog/112.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Rename "envoy_hcp_metrics_bind_socket_dir" to "envoy_telemetry_collector_bind_socket_dir", which removes inaccurate HCP references.
+```

--- a/internal/bootstrap/bootstrap_config.go
+++ b/internal/bootstrap/bootstrap_config.go
@@ -54,10 +54,10 @@ type BootstrapConfig struct {
 	// stats_config.stats_tags can be made by overriding envoy_stats_config_json.
 	StatsTags []string `mapstructure:"envoy_stats_tags"`
 
-	// HCPMetricsBindSocketDir is a string that configures the directory for a
+	// TelemetryCollectorBindSocketDir is a string that configures the directory for a
 	// unix socket where Envoy will forward metrics. These metrics get pushed to
-	// the HCP Metrics collector to show service mesh metrics on HCP.
-	HCPMetricsBindSocketDir string `mapstructure:"envoy_hcp_metrics_bind_socket_dir"`
+	// the consul telemetry collector.
+	TelemetryCollectorBindSocketDir string `mapstructure:"envoy_telemetry_collector_bind_socket_dir"`
 
 	// PrometheusBindAddr configures an <ip>:<port> on which the Envoy will listen
 	// and expose a single /metrics HTTP endpoint for Prometheus to scrape. It
@@ -248,9 +248,9 @@ func (c *BootstrapConfig) ConfigureArgs(args *BootstrapTplArgs, omitDeprecatedTa
 		args.StatsFlushInterval = c.StatsFlushInterval
 	}
 
-	// Setup HCP Metrics if needed. This MUST happen after the Static*JSON is set above
-	if c.HCPMetricsBindSocketDir != "" {
-		appendHCPMetricsConfig(args, c.HCPMetricsBindSocketDir)
+	// Setup telemetry collector if needed. This MUST happen after the Static*JSON is set above
+	if c.TelemetryCollectorBindSocketDir != "" {
+		appendTelemetryCollectorConfig(args, c.TelemetryCollectorBindSocketDir)
 	}
 
 	return nil
@@ -811,16 +811,16 @@ func (c *BootstrapConfig) generateListenerConfig(args *BootstrapTplArgs, bindAdd
 	return nil
 }
 
-// appendHCPMetricsConfig generates config to enable a socket at path: <hcpMetricsBindSocketDir>/<hash of compound proxy ID>.sock
+// appendTelemetryCollectorConfig generates config to enable a socket at path: <telemetryCollectorBindSocketDir>/<hash of compound proxy ID>.sock
 // We take the hash of the compound proxy ID for a few reasons:
 //
 //   - The proxy ID is included because this socket path must be unique per proxy. Each Envoy proxy will ship
-//     its metrics to HCP using its own loopback listener at this path.
+//     its metrics to the consul telemetry collector using its own loopback listener at this path.
 //
 //   - The hash is needed because UNIX domain socket paths must be less than 104 characters. By using a b64 encoded
 //     SHA1 hash we end up with 27 chars for the name, 5 chars for the extension, and the remainder is saved for
 //     the configurable socket dir. The length of the directory's path is validated on writes to avoid going over.
-func appendHCPMetricsConfig(args *BootstrapTplArgs, hcpMetricsBindSocketDir string) {
+func appendTelemetryCollectorConfig(args *BootstrapTplArgs, telemetryCollectorBindSocketDir string) {
 	// Normalize namespace to "default". This ensures we match the namespace behaviour in proxycfg package,
 	// where a dynamic listener will be created at the same socket path via xDS.
 	ns := args.Namespace
@@ -832,7 +832,7 @@ func appendHCPMetricsConfig(args *BootstrapTplArgs, hcpMetricsBindSocketDir stri
 	h := sha1.New()
 	h.Write([]byte(id))
 	hash := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
-	path := path.Join(hcpMetricsBindSocketDir, hash+".sock")
+	path := path.Join(telemetryCollectorBindSocketDir, hash+".sock")
 
 	if args.StatsSinksJSON != "" {
 		args.StatsSinksJSON += ",\n"
@@ -844,7 +844,7 @@ func appendHCPMetricsConfig(args *BootstrapTplArgs, hcpMetricsBindSocketDir stri
 		  "transport_api_version": "V3",
 		  "grpc_service": {
 			"envoy_grpc": {
-			  "cluster_name": "hcp_metrics_collector"
+			  "cluster_name": "consul_telemetry_collector_loopback"
 			}
 		  }
 		}
@@ -854,11 +854,11 @@ func appendHCPMetricsConfig(args *BootstrapTplArgs, hcpMetricsBindSocketDir stri
 		args.StaticClustersJSON += ",\n"
 	}
 	args.StaticClustersJSON += fmt.Sprintf(`{
-		"name": "hcp_metrics_collector",
+		"name": "consul_telemetry_collector_loopback",
 		"type": "STATIC",
 		"http2_protocol_options": {},
 		"loadAssignment": {
-		  "clusterName": "hcp_metrics_collector",
+		  "clusterName": "consul_telemetry_collector_loopback",
 		  "endpoints": [
 			{
 			  "lbEndpoints": [

--- a/internal/bootstrap/bootstrap_config_test.go
+++ b/internal/bootstrap/bootstrap_config_test.go
@@ -531,25 +531,25 @@ const (
 	}
 }`
 
-	expectedHCPMetricsStatsSink = `{
+	expectedTelemetryCollectorMetricsStatsSink = `{
 	"name": "envoy.stat_sinks.metrics_service",
 	"typed_config": {
 	  "@type": "type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig",
 	  "transport_api_version": "V3",
 	  "grpc_service": {
 		"envoy_grpc": {
-		  "cluster_name": "hcp_metrics_collector"
+		  "cluster_name": "consul_telemetry_collector_loopback"
 		}
 	  }
 	}
   }`
 
-	expectedHCPMetricsCluster = `{
-	"name": "hcp_metrics_collector",
+	expectedTelemetryCollectorMetricsCluster = `{
+	"name": "consul_telemetry_collector_loopback",
 	"type": "STATIC",
 	"http2_protocol_options": {},
 	"loadAssignment": {
-	  "clusterName": "hcp_metrics_collector",
+	  "clusterName": "consul_telemetry_collector_loopback",
 	  "endpoints": [
 		{
 		  "lbEndpoints": [
@@ -557,7 +557,7 @@ const (
 			  "endpoint": {
 				"address": {
 				  "pipe": {
-					"path": "/tmp/consul/hcp-metrics/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
+					"path": "/tmp/consul/telemetry-collector/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
 				  }
 				}
 			  }
@@ -620,12 +620,12 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "hcp-metrics-sink",
+			name: "telemetry-collector-sink",
 			baseArgs: BootstrapTplArgs{
 				ProxyID: "web-sidecar-proxy",
 			},
 			input: BootstrapConfig{
-				HCPMetricsBindSocketDir: "/tmp/consul/hcp-metrics",
+				TelemetryCollectorBindSocketDir: "/tmp/consul/telemetry-collector",
 			},
 			wantArgs: BootstrapTplArgs{
 				ProxyID:         "web-sidecar-proxy",
@@ -637,17 +637,17 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 					  "transport_api_version": "V3",
 					  "grpc_service": {
 						"envoy_grpc": {
-						  "cluster_name": "hcp_metrics_collector"
+						  "cluster_name": "consul_telemetry_collector_loopback"
 						}
 					  }
 					}
 				  }`,
 				StaticClustersJSON: `{
-					"name": "hcp_metrics_collector",
+					"name": "consul_telemetry_collector_loopback",
 					"type": "STATIC",
 					"http2_protocol_options": {},
 					"loadAssignment": {
-					  "clusterName": "hcp_metrics_collector",
+					  "clusterName": "consul_telemetry_collector_loopback",
 					  "endpoints": [
 						{
 						  "lbEndpoints": [
@@ -655,7 +655,7 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 							  "endpoint": {
 								"address": {
 								  "pipe": {
-									"path": "/tmp/consul/hcp-metrics/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
+									"path": "/tmp/consul/telemetry-collector/gqmuzdHCUPAEY5mbF8vgkZCNI14.sock"
 								  }
 								}
 							  }
@@ -1632,7 +1632,7 @@ func TestConsulTagSpecifiers(t *testing.T) {
 	}
 }
 
-func TestAppendHCPMetrics(t *testing.T) {
+func TestAppendTelmetryCollectorMetrics(t *testing.T) {
 	tests := map[string]struct {
 		inputArgs     *BootstrapTplArgs
 		bindSocketDir string
@@ -1642,22 +1642,22 @@ func TestAppendHCPMetrics(t *testing.T) {
 			inputArgs: &BootstrapTplArgs{
 				ProxyID: "web-sidecar-proxy",
 			},
-			bindSocketDir: "/tmp/consul/hcp-metrics",
+			bindSocketDir: "/tmp/consul/telemetry-collector",
 			wantArgs: &BootstrapTplArgs{
 				ProxyID:            "web-sidecar-proxy",
-				StatsSinksJSON:     expectedHCPMetricsStatsSink,
-				StaticClustersJSON: expectedHCPMetricsCluster,
+				StatsSinksJSON:     expectedTelemetryCollectorMetricsStatsSink,
+				StaticClustersJSON: expectedTelemetryCollectorMetricsCluster,
 			},
 		},
 		"dir-with-trailing-slash": {
 			inputArgs: &BootstrapTplArgs{
 				ProxyID: "web-sidecar-proxy",
 			},
-			bindSocketDir: "/tmp/consul/hcp-metrics",
+			bindSocketDir: "/tmp/consul/telemetry-collector",
 			wantArgs: &BootstrapTplArgs{
 				ProxyID:            "web-sidecar-proxy",
-				StatsSinksJSON:     expectedHCPMetricsStatsSink,
-				StaticClustersJSON: expectedHCPMetricsCluster,
+				StatsSinksJSON:     expectedTelemetryCollectorMetricsStatsSink,
+				StaticClustersJSON: expectedTelemetryCollectorMetricsCluster,
 			},
 		},
 		"append-clusters-and-stats-sink": {
@@ -1666,18 +1666,18 @@ func TestAppendHCPMetrics(t *testing.T) {
 				StatsSinksJSON:     expectedStatsdSink,
 				StaticClustersJSON: expectedSelfAdminCluster,
 			},
-			bindSocketDir: "/tmp/consul/hcp-metrics",
+			bindSocketDir: "/tmp/consul/telemetry-collector",
 			wantArgs: &BootstrapTplArgs{
 				ProxyID:            "web-sidecar-proxy",
-				StatsSinksJSON:     expectedStatsdSink + ",\n" + expectedHCPMetricsStatsSink,
-				StaticClustersJSON: expectedSelfAdminCluster + ",\n" + expectedHCPMetricsCluster,
+				StatsSinksJSON:     expectedStatsdSink + ",\n" + expectedTelemetryCollectorMetricsStatsSink,
+				StaticClustersJSON: expectedSelfAdminCluster + ",\n" + expectedTelemetryCollectorMetricsCluster,
 			},
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			appendHCPMetricsConfig(tt.inputArgs, tt.bindSocketDir)
+			appendTelemetryCollectorConfig(tt.inputArgs, tt.bindSocketDir)
 
 			// Some of our JSON strings are comma separated objects to be
 			// insertedinto an array which is not valid JSON on it's own so wrap

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -112,7 +112,7 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 			},
 		},
-		"hcp-metrics": {
+		"telemetry-collector": {
 			cfg: &Config{
 				Service: &ServiceConfig{
 					ServiceID: "web-proxy",
@@ -133,7 +133,7 @@ func TestBootstrapConfig(t *testing.T) {
 				Namespace: "default",
 				NodeName:  nodeName,
 				Config: makeStruct(map[string]any{
-					"envoy_hcp_metrics_bind_socket_dir": "/tmp/consul/hcp-metrics",
+					"envoy_telemetry_collector_bind_socket_dir": "/tmp/consul/telemetry-collector",
 				}),
 			},
 		},

--- a/pkg/consuldp/testdata/TestBootstrapConfig/telemetry-collector.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/telemetry-collector.golden
@@ -56,11 +56,11 @@
         }
       },
       {
-        "name": "hcp_metrics_collector",
+        "name": "consul_telemetry_collector_loopback",
         "type": "STATIC",
         "http2_protocol_options": {},
         "loadAssignment": {
-          "clusterName": "hcp_metrics_collector",
+          "clusterName": "consul_telemetry_collector_loopback",
           "endpoints": [
             {
               "lbEndpoints": [
@@ -68,7 +68,7 @@
                   "endpoint": {
                     "address": {
                       "pipe": {
-                        "path": "/tmp/consul/hcp-metrics/0UZwF69tP4X7LqMgNbB_v_R6Sjk.sock"
+                        "path": "/tmp/consul/telemetry-collector/0UZwF69tP4X7LqMgNbB_v_R6Sjk.sock"
                       }
                     }
                   }
@@ -88,7 +88,7 @@
         "transport_api_version": "V3",
         "grpc_service": {
           "envoy_grpc": {
-            "cluster_name": "hcp_metrics_collector"
+            "cluster_name": "consul_telemetry_collector_loopback"
           }
         }
       }


### PR DESCRIPTION
This PR is the equivalent of https://github.com/hashicorp/consul/pull/17327 for consul-dataplane.

Renamed the bind_socket_dir config key to remove the hcp reference. The collector can be used without HCP so it made more sense to generalize the name. This PR removes references to HCP.

