### PR TITLE
proxy-lifecycle: catch SIGTERM and initiate graceful shutdown

### DIFF
--- a/.changelog/130.txt
+++ b/.changelog/130.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Catch SIGTERM and SIGINT to initate graceful shutdown in accordance with proxy lifecycle management configuration.
+```

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -35,8 +35,6 @@ jobs:
       - run: go test ./... -p 1 # disable parallelism to avoid port conflicts from default metrics and lifecycle server configuration
   integration-tests:
     name: integration-tests
-    env:
-      DOCKER_API_VERSION: 1.41
     needs:
       - get-go-version
     runs-on: ubuntu-latest

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -35,6 +35,8 @@ jobs:
       - run: go test ./... -p 1 # disable parallelism to avoid port conflicts from default metrics and lifecycle server configuration
   integration-tests:
     name: integration-tests
+    env:
+      DOCKER_API_VERSION: 1.41
     needs:
       - get-go-version
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ else
 	$(error Cannot generate changelog without LAST_RELEASE_GIT_TAG)
 endif
 
-INTEGRATION_TESTS_SERVER_IMAGE    ?= hashicorppreview/consul:1.14-dev
+INTEGRATION_TESTS_SERVER_IMAGE    ?= hashicorppreview/consul:1.15-dev
 INTEGRATION_TESTS_DATAPLANE_IMAGE ?= $(PRODUCT_NAME)/release-default:$(VERSION)
 
 .PHONY: expand-integration-tests-output-dir

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -80,6 +80,8 @@ var (
 	shutdownGracePeriodSeconds    int
 	gracefulShutdownPath          string
 	gracefulPort                  int
+
+	dumpEnvoyConfigOnExitEnabled bool
 )
 
 func init() {
@@ -157,6 +159,9 @@ func init() {
 	IntVar(&shutdownGracePeriodSeconds, "shutdown-grace-period-seconds", 0, "DP_SHUTDOWN_GRACE_PERIOD_SECONDS", "Amount of time to wait after receiving a SIGTERM signal before terminating the proxy.")
 	StringVar(&gracefulShutdownPath, "graceful-shutdown-path", "/graceful_shutdown", "DP_GRACEFUL_SHUTDOWN_PATH", "An HTTP path to serve the graceful shutdown endpoint.")
 	IntVar(&gracefulPort, "graceful-port", 20300, "DP_GRACEFUL_PORT", "A port to serve HTTP endpoints for graceful shutdown.")
+
+	// Default is false, may be useful for debugging unexpected termination.
+	BoolVar(&dumpEnvoyConfigOnExitEnabled, "dump-envoy-config-on-exit", false, "DP_DUMP_ENVOY_CONFIG_ON_EXIT", "Call the Envoy /config_dump endpoint during consul-dataplane controlled shutdown.")
 }
 
 // validateFlags performs semantic validation of the flag values
@@ -245,6 +250,7 @@ func main() {
 			ShutdownGracePeriodSeconds:    shutdownGracePeriodSeconds,
 			GracefulShutdownPath:          gracefulShutdownPath,
 			GracefulPort:                  gracefulPort,
+			DumpEnvoyConfigOnExitEnabled:  dumpEnvoyConfigOnExitEnabled,
 			ExtraArgs:                     flag.Args(),
 		},
 		XDSServer: &consuldp.XDSServer{

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -265,17 +265,14 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	signal.NotifyContext(ctx, syscall.SIGINT)
-
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		// Block waiting for SIGTERM
 		<-sigCh
 
-		// Trigger graceful shutdown before canceling parent context
-		consuldpInstance.GracefulShutdown()
+		consuldpInstance.GracefulShutdown(cancel)
 	}()
 
 	err = consuldpInstance.Run(ctx)

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -173,13 +173,13 @@ func validateFlags() {
 	}
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	if printVersion {
 		fmt.Printf("Consul Dataplane v%s\n", version.GetHumanVersion())
 		fmt.Printf("Revision %s\n", version.GitCommit)
-		return
+		return nil
 	}
 
 	readServiceIDFromFile()
@@ -265,7 +265,7 @@ func main() {
 
 	consuldpInstance, err := consuldp.NewConsulDP(consuldpCfg)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -281,7 +281,11 @@ func main() {
 		consuldpInstance.GracefulShutdown(cancel)
 	}()
 
-	err = consuldpInstance.Run(ctx)
+	return consuldpInstance.Run(ctx)
+}
+
+func main() {
+	err := run()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/integration-tests/helpers/dataplane.go
+++ b/integration-tests/helpers/dataplane.go
@@ -24,7 +24,7 @@ type DataplaneConfig struct {
 	DNSBindPort            string
 	ServiceMetricsURL      string
 	ShutdownGracePeriod    string
-	ShutdownDrainListeners string
+	ShutdownDrainListeners bool
 }
 
 func (cfg DataplaneConfig) ToArgs() []string {
@@ -50,8 +50,8 @@ func (cfg DataplaneConfig) ToArgs() []string {
 		args = append(args, "-shutdown-grace-period", cfg.ShutdownGracePeriod)
 	}
 
-	if cfg.ShutdownDrainListeners != "" {
-		args = append(args, "-shutdown-drain-listeners", cfg.ShutdownDrainListeners)
+	if cfg.ShutdownDrainListeners {
+		args = append(args, "-shutdown-drain-listeners")
 	}
 
 	return args
@@ -81,6 +81,8 @@ func RunDataplane(t *testing.T, pod *Pod, suite *Suite, cfg DataplaneConfig) *Co
 			pod.MappedPorts[EnvoyAdminPort],
 		)
 
+		// TODO: This will fail because the integration test now performs a
+		// graceful shutdown of Envoy before reaching this point.
 		rsp, err := httpClient.Get(url)
 		if err != nil {
 			t.Logf("failed to dump Envoy config: %v\n", err)

--- a/integration-tests/helpers/dataplane.go
+++ b/integration-tests/helpers/dataplane.go
@@ -16,15 +16,15 @@ import (
 var EnvoyAdminPort = TCP(30000)
 
 type DataplaneConfig struct {
-	Addresses              string
-	ServiceNodeName        string
-	ProxyServiceID         string
-	LoginAuthMethod        string
-	LoginBearerToken       string
-	DNSBindPort            string
-	ServiceMetricsURL      string
-	ShutdownGracePeriod    string
-	ShutdownDrainListeners bool
+	Addresses                  string
+	ServiceNodeName            string
+	ProxyServiceID             string
+	LoginAuthMethod            string
+	LoginBearerToken           string
+	DNSBindPort                string
+	ServiceMetricsURL          string
+	ShutdownGracePeriodSeconds string
+	ShutdownDrainListeners     bool
 }
 
 func (cfg DataplaneConfig) ToArgs() []string {
@@ -46,8 +46,8 @@ func (cfg DataplaneConfig) ToArgs() []string {
 		"-telemetry-prom-service-metrics-url", cfg.ServiceMetricsURL,
 	}
 
-	if cfg.ShutdownGracePeriod != "" {
-		args = append(args, "-shutdown-grace-period", cfg.ShutdownGracePeriod)
+	if cfg.ShutdownGracePeriodSeconds != "" {
+		args = append(args, "-shutdown-grace-period-seconds", cfg.ShutdownGracePeriodSeconds)
 	}
 
 	if cfg.ShutdownDrainListeners {

--- a/integration-tests/helpers/dataplane.go
+++ b/integration-tests/helpers/dataplane.go
@@ -44,9 +44,16 @@ func (cfg DataplaneConfig) ToArgs() []string {
 		"-telemetry-use-central-config",
 		"-telemetry-prom-scrape-path", "/metrics",
 		"-telemetry-prom-service-metrics-url", cfg.ServiceMetricsURL,
-		"-shutdown-grace-period", cfg.ShutdownGracePeriod,
-		"-shutdown-drain-listeners", cfg.ShutdownDrainListeners,
 	}
+
+	if cfg.ShutdownGracePeriod != "" {
+		args = append(args, "-shutdown-grace-period", cfg.ShutdownGracePeriod)
+	}
+
+	if cfg.ShutdownDrainListeners != "" {
+		args = append(args, "-shutdown-drain-listeners", cfg.ShutdownDrainListeners)
+	}
+
 	return args
 }
 

--- a/integration-tests/helpers/dataplane.go
+++ b/integration-tests/helpers/dataplane.go
@@ -16,13 +16,15 @@ import (
 var EnvoyAdminPort = TCP(30000)
 
 type DataplaneConfig struct {
-	Addresses         string
-	ServiceNodeName   string
-	ProxyServiceID    string
-	LoginAuthMethod   string
-	LoginBearerToken  string
-	DNSBindPort       string
-	ServiceMetricsURL string
+	Addresses              string
+	ServiceNodeName        string
+	ProxyServiceID         string
+	LoginAuthMethod        string
+	LoginBearerToken       string
+	DNSBindPort            string
+	ServiceMetricsURL      string
+	ShutdownGracePeriod    string
+	ShutdownDrainListeners string
 }
 
 func (cfg DataplaneConfig) ToArgs() []string {
@@ -42,7 +44,8 @@ func (cfg DataplaneConfig) ToArgs() []string {
 		"-telemetry-use-central-config",
 		"-telemetry-prom-scrape-path", "/metrics",
 		"-telemetry-prom-service-metrics-url", cfg.ServiceMetricsURL,
-		// TODO: proxy lifecycle shutdown args
+		"-shutdown-grace-period", cfg.ShutdownGracePeriod,
+		"-shutdown-drain-listeners", cfg.ShutdownDrainListeners,
 	}
 	return args
 }

--- a/integration-tests/helpers/dataplane.go
+++ b/integration-tests/helpers/dataplane.go
@@ -42,6 +42,7 @@ func (cfg DataplaneConfig) ToArgs() []string {
 		"-telemetry-use-central-config",
 		"-telemetry-prom-scrape-path", "/metrics",
 		"-telemetry-prom-service-metrics-url", cfg.ServiceMetricsURL,
+		// TODO: proxy lifecycle shutdown args
 	}
 	return args
 }

--- a/integration-tests/helpers/dataplane.go
+++ b/integration-tests/helpers/dataplane.go
@@ -16,15 +16,15 @@ import (
 var EnvoyAdminPort = TCP(30000)
 
 type DataplaneConfig struct {
-	Addresses                  string
-	ServiceNodeName            string
-	ProxyServiceID             string
-	LoginAuthMethod            string
-	LoginBearerToken           string
-	DNSBindPort                string
-	ServiceMetricsURL          string
-	ShutdownGracePeriodSeconds string
-	ShutdownDrainListeners     bool
+	Addresses                     string
+	ServiceNodeName               string
+	ProxyServiceID                string
+	LoginAuthMethod               string
+	LoginBearerToken              string
+	DNSBindPort                   string
+	ServiceMetricsURL             string
+	ShutdownGracePeriodSeconds    string
+	ShutdownDrainListenersEnabled bool
 }
 
 func (cfg DataplaneConfig) ToArgs() []string {
@@ -50,7 +50,7 @@ func (cfg DataplaneConfig) ToArgs() []string {
 		args = append(args, "-shutdown-grace-period-seconds", cfg.ShutdownGracePeriodSeconds)
 	}
 
-	if cfg.ShutdownDrainListeners {
+	if cfg.ShutdownDrainListenersEnabled {
 		args = append(args, "-shutdown-drain-listeners")
 	}
 

--- a/integration-tests/helpers/suite.go
+++ b/integration-tests/helpers/suite.go
@@ -98,6 +98,7 @@ func (s *Suite) RunContainer(t *testing.T, name string, captureLogs bool, req Co
 
 	require.NoError(t, container.StartLogProducer(ctx))
 
+	// TODO: Handle this more gracefully if container was terminated out of band
 	t.Cleanup(func() {
 		if err := container.StopLogProducer(); err != nil {
 			t.Logf("failed to stop log producer: %v\n", err)

--- a/integration-tests/helpers/suite.go
+++ b/integration-tests/helpers/suite.go
@@ -204,11 +204,17 @@ func (s *Suite) Volume(t *testing.T) *Volume {
 		require.NoError(t, err)
 
 		t.Cleanup(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+			s.mu.Lock()
+			defer s.mu.Unlock()
 
-			if err := docker.VolumeRemove(ctx, v.Name, true); err != nil {
-				t.Logf("failed to remove volume: %v", err)
+			if s.volume != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				if err := docker.VolumeRemove(ctx, v.Name, true); err != nil {
+					t.Logf("failed to remove volume: %v", err)
+				}
+				s.volume = nil
 			}
 		})
 

--- a/integration-tests/helpers/suite.go
+++ b/integration-tests/helpers/suite.go
@@ -98,7 +98,6 @@ func (s *Suite) RunContainer(t *testing.T, name string, captureLogs bool, req Co
 
 	require.NoError(t, container.StartLogProducer(ctx))
 
-	// TODO: Handle this more gracefully if container was terminated out of band
 	t.Cleanup(func() {
 		if err := container.StopLogProducer(); err != nil {
 			t.Logf("failed to stop log producer: %v\n", err)

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -194,15 +194,15 @@ func TestIntegration(t *testing.T) {
 	RunService(t, suite, frontendPod, "frontend")
 
 	frontendDataplane := RunDataplane(t, frontendPod, suite, DataplaneConfig{
-		Addresses:                  server.Container.ContainerIP,
-		ServiceNodeName:            SyntheticNodeName,
-		ProxyServiceID:             "frontend-sidecar",
-		LoginAuthMethod:            authMethod.Name,
-		LoginBearerToken:           authMethod.GenerateToken(t, "frontend"),
-		DNSBindPort:                dnsUDPPort.Port(),
-		ServiceMetricsURL:          "http://localhost:8080",
-		ShutdownGracePeriodSeconds: "10",
-		ShutdownDrainListeners:     true,
+		Addresses:                     server.Container.ContainerIP,
+		ServiceNodeName:               SyntheticNodeName,
+		ProxyServiceID:                "frontend-sidecar",
+		LoginAuthMethod:               authMethod.Name,
+		LoginBearerToken:              authMethod.GenerateToken(t, "frontend"),
+		DNSBindPort:                   dnsUDPPort.Port(),
+		ServiceMetricsURL:             "http://localhost:8080",
+		ShutdownGracePeriodSeconds:    "10",
+		ShutdownDrainListenersEnabled: true,
 	})
 
 	// Intentions are configured as default deny in helpers/server.go

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -22,12 +22,12 @@ import (
 )
 
 var (
-	// upstreamLocalBindPort is the port the frontend sidecar will bind the local
-	// listener for its backend upstream to.
+	// upstreamLocalBindPort is the port each sidecar will bind the local
+	// listener for its upstream to.
 	upstreamLocalBindPort = TCP(10000)
 
 	// proxyInboundListenerPort is the port the sidecars will bind their public
-	// listeners to. Only the backend sidecar's public port is used in these tests.
+	// listeners to.
 	proxyInboundListenerPort = TCP(20000)
 
 	// dnsUDPPort is UDP the port Consul Dataplane's DNS proxy wil be bound to.
@@ -134,6 +134,14 @@ func TestIntegration(t *testing.T) {
 		Proxy: &api.AgentServiceConnectProxyConfig{
 			DestinationServiceName: "backend",
 			LocalServicePort:       8080,
+			Upstreams: []api.Upstream{
+				{
+					DestinationType:  api.UpstreamDestTypeService,
+					DestinationName:  "frontend",
+					LocalBindPort:    upstreamLocalBindPort.Int(),
+					LocalBindAddress: "0.0.0.0",
+				},
+			},
 		},
 	})
 

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -4,6 +4,7 @@
 package integrationtests
 
 import (
+	// "context"
 	"flag"
 	"fmt"
 	"net"
@@ -332,7 +333,8 @@ func TestIntegration(t *testing.T) {
 		backendPod.MappedPorts[upstreamLocalBindPort],
 	)
 
-	// TODO: Send SIGTERM to start graceful shutdown of frontend service
+	// Send SIGTERM to start graceful shutdown of frontend service
+	// frontendPod.Container.Terminate(context.Background())
 
 	// Expect outgoing connections through sidecar are allowed until shutdown
 	// grace period has elapsed.

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -151,13 +151,14 @@ func TestIntegration(t *testing.T) {
 	RunService(t, suite, backendPod, "backend")
 
 	backendDataplane := RunDataplane(t, backendPod, suite, DataplaneConfig{
-		Addresses:         server.Container.ContainerIP,
-		ServiceNodeName:   SyntheticNodeName,
-		ProxyServiceID:    "backend-sidecar",
-		LoginAuthMethod:   authMethod.Name,
-		LoginBearerToken:  authMethod.GenerateToken(t, "backend"),
-		DNSBindPort:       dnsUDPPort.Port(),
-		ServiceMetricsURL: "http://localhost:8080",
+		Addresses:                    server.Container.ContainerIP,
+		ServiceNodeName:              SyntheticNodeName,
+		ProxyServiceID:               "backend-sidecar",
+		LoginAuthMethod:              authMethod.Name,
+		LoginBearerToken:             authMethod.GenerateToken(t, "backend"),
+		DNSBindPort:                  dnsUDPPort.Port(),
+		ServiceMetricsURL:            "http://localhost:8080",
+		DumpEnvoyConfigOnExitEnabled: true,
 	})
 
 	frontendPod := RunPod(t, suite, "frontend", []nat.Port{
@@ -203,6 +204,7 @@ func TestIntegration(t *testing.T) {
 		ServiceMetricsURL:             "http://localhost:8080",
 		ShutdownGracePeriodSeconds:    "10",
 		ShutdownDrainListenersEnabled: true,
+		DumpEnvoyConfigOnExitEnabled:  true,
 	})
 
 	// Intentions are configured as default deny in helpers/server.go

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -338,7 +338,9 @@ func TestIntegration(t *testing.T) {
 
 	// Send SIGTERM to dataplane to start graceful shutdown
 	containerID := frontendDataplane.Container.GetContainerID()
-	cli, err := client.NewClientWithOpts()
+	cli, err := client.NewClientWithOpts(
+		client.WithAPIVersionNegotiation(),
+	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error initializing docker client: %s\n", err)
 		os.Exit(1)

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -194,15 +194,15 @@ func TestIntegration(t *testing.T) {
 	RunService(t, suite, frontendPod, "frontend")
 
 	frontendDataplane := RunDataplane(t, frontendPod, suite, DataplaneConfig{
-		Addresses:              server.Container.ContainerIP,
-		ServiceNodeName:        SyntheticNodeName,
-		ProxyServiceID:         "frontend-sidecar",
-		LoginAuthMethod:        authMethod.Name,
-		LoginBearerToken:       authMethod.GenerateToken(t, "frontend"),
-		DNSBindPort:            dnsUDPPort.Port(),
-		ServiceMetricsURL:      "http://localhost:8080",
-		ShutdownGracePeriod:    "10",
-		ShutdownDrainListeners: true,
+		Addresses:                  server.Container.ContainerIP,
+		ServiceNodeName:            SyntheticNodeName,
+		ProxyServiceID:             "frontend-sidecar",
+		LoginAuthMethod:            authMethod.Name,
+		LoginBearerToken:           authMethod.GenerateToken(t, "frontend"),
+		DNSBindPort:                dnsUDPPort.Port(),
+		ServiceMetricsURL:          "http://localhost:8080",
+		ShutdownGracePeriodSeconds: "10",
+		ShutdownDrainListeners:     true,
 	})
 
 	// Intentions are configured as default deny in helpers/server.go

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -289,7 +289,7 @@ func TestIntegration(t *testing.T) {
 		}, 30*time.Second, 3*time.Second, "could not find admin access logs in output")
 	}
 
-	// Overwrite deny intetion and allow two-way connections to prepare for
+	// Overwrite deny intention and allow two-way connections to prepare for
 	// testing graceful shutdown
 	server.SetConfigEntry(t, &api.ServiceIntentionsConfigEntry{
 		Kind: api.ServiceIntentions,

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -295,6 +295,8 @@ type EnvoyConfig struct {
 	GracefulShutdownPath string
 	// GracefulPort is the port on which the HTTP server for graceful shutdown endpoints will be available.
 	GracefulPort int
+	// DumpEnvoyConfigOnExitEnabled configures whether to call Envoy's /config_dump endpoint during consul-dataplane controlled shutdown.
+	DumpEnvoyConfigOnExitEnabled bool
 	// ExtraArgs are the extra arguments passed to envoy at startup of the proxy
 	ExtraArgs []string
 }

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -305,3 +305,7 @@ func (cdp *ConsulDataplane) envoyProxyConfig(cfg []byte) envoy.ProxyConfig {
 		ExtraArgs:       extraArgs,
 	}
 }
+
+func (cdp *ConsulDataplane) GracefulShutdown() {
+	cdp.lifecycleConfig.gracefulShutdown()
+}

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -306,6 +306,12 @@ func (cdp *ConsulDataplane) envoyProxyConfig(cfg []byte) envoy.ProxyConfig {
 	}
 }
 
-func (cdp *ConsulDataplane) GracefulShutdown() {
-	cdp.lifecycleConfig.gracefulShutdown()
+func (cdp *ConsulDataplane) GracefulShutdown(cancel context.CancelFunc) {
+	// If proxy lifecycle manager has not been initialized, cancel parent context and
+	// proceed to exit rather than attempting graceful shutdown
+	if cdp.lifecycleConfig != nil {
+		cdp.lifecycleConfig.gracefulShutdown()
+	} else {
+		cancel()
+	}
 }

--- a/pkg/consuldp/lifecycle.go
+++ b/pkg/consuldp/lifecycle.go
@@ -92,7 +92,7 @@ func (m *lifecycleConfig) startLifecycleManager(ctx context.Context) error {
 	m.gracefulShutdownPath = cdpLifecycleShutdownPath
 
 	m.logger.Info(fmt.Sprintf("setting graceful shutdown path: %s\n", cdpLifecycleShutdownPath))
-	mux.HandleFunc(cdpLifecycleShutdownPath, m.gracefulShutdown)
+	mux.HandleFunc(cdpLifecycleShutdownPath, m.gracefulShutdownHandler)
 
 	// Determine what the proxy lifecycle management server bind port is. It can be
 	// set as a flag.
@@ -144,9 +144,16 @@ func (m *lifecycleConfig) lifecycleServerExited() <-chan struct{} {
 	return m.errorExitCh
 }
 
-// gracefulShutdown blocks until shutdownGracePeriodSeconds seconds have elapsed, and, if
+func (m *lifecycleConfig) gracefulShutdownHandler(rw http.ResponseWriter, _ *http.Request) {
+	m.gracefulShutdown()
+
+	// Return HTTP 200 Success
+	rw.WriteHeader(http.StatusOK)
+}
+
+// gracefulShutdown blocks until shutdownGracePeriod seconds have elapsed, and, if
 // configured, will drain inbound connections to Envoy listeners during that time.
-func (m *lifecycleConfig) gracefulShutdown(rw http.ResponseWriter, _ *http.Request) {
+func (m *lifecycleConfig) gracefulShutdown() {
 	m.logger.Info("initiating shutdown")
 
 	// Create a context that  will signal a cancel at the specified duration.
@@ -189,7 +196,4 @@ func (m *lifecycleConfig) gracefulShutdown(rw http.ResponseWriter, _ *http.Reque
 
 	// Wait for context timeout to elapse
 	wg.Wait()
-
-	// Return HTTP 200 Success
-	rw.WriteHeader(http.StatusOK)
 }

--- a/pkg/consuldp/lifecycle.go
+++ b/pkg/consuldp/lifecycle.go
@@ -145,7 +145,9 @@ func (m *lifecycleConfig) lifecycleServerExited() <-chan struct{} {
 }
 
 func (m *lifecycleConfig) gracefulShutdownHandler(rw http.ResponseWriter, _ *http.Request) {
-	m.gracefulShutdown()
+	// Kick off graceful shutdown in a separate goroutine to avoid blocking
+	// sending an HTTP response
+	go m.gracefulShutdown()
 
 	// Return HTTP 200 Success
 	rw.WriteHeader(http.StatusOK)

--- a/pkg/consuldp/lifecycle_test.go
+++ b/pkg/consuldp/lifecycle_test.go
@@ -90,6 +90,10 @@ func TestLifecycleServerEnabled(t *testing.T) {
 		log.Printf("config = %v", c)
 
 		t.Run(name, func(t *testing.T) {
+			// Add a small margin of error for assertions checking expected
+			// behavior within the shutdown grace period window.
+			shutdownTimeout := time.Duration((c.shutdownGracePeriodSeconds + 5)) * time.Second
+
 			cfg := Config{
 				Envoy: &EnvoyConfig{
 					AdminBindAddress:              envoyAdminAddr,
@@ -148,15 +152,27 @@ func TestLifecycleServerEnabled(t *testing.T) {
 
 			resp, err := http.Get(url)
 
-			// Use mock client to check expected method calls to proxy manager
+			// HTTP handler is not blocking, so need to wait and check mock
+			// client for expected method calls to proxy manager within
+			// expected shutdown grace period plus a small margin of error.
 			if c.shutdownDrainListenersEnabled {
-				require.Equal(t, 1, m.proxy.(*mockProxy).drainCalled, "Proxy.Drain() not called as expected")
+				require.Eventually(t, func() bool {
+					return m.proxy.(*mockProxy).drainCalled == 1
+				}, shutdownTimeout, time.Second, "Proxy.Drain() not called as expected")
 			} else {
-				require.Equal(t, 0, m.proxy.(*mockProxy).drainCalled, "Proxy.Drain() called unexpectedly")
+				require.Never(t, func() bool {
+					return m.proxy.(*mockProxy).drainCalled == 1
+				}, shutdownTimeout, time.Second, "Proxy.Drain() called unexpectedly")
 			}
 
-			require.Equal(t, 1, m.proxy.(*mockProxy).quitCalled, "Proxy.Quit() not called as expected")
-			require.Equal(t, 0, m.proxy.(*mockProxy).killCalled, "Proxy.Kill() called unexpectedly")
+			require.Eventually(t, func() bool {
+				return m.proxy.(*mockProxy).quitCalled == 1
+			}, shutdownTimeout, time.Second, "Proxy.Quit() not called as expected")
+
+			// Expect that proxy is not forcefully killed as part of graceful shutdown.
+			require.Never(t, func() bool {
+				return m.proxy.(*mockProxy).killCalled == 1
+			}, shutdownTimeout, time.Second, "Proxy.Kill() called unexpectedly")
 
 			require.NoError(t, err)
 			require.NotNil(t, resp)

--- a/pkg/consuldp/lifecycle_test.go
+++ b/pkg/consuldp/lifecycle_test.go
@@ -209,3 +209,7 @@ func (p *mockProxy) Kill() error {
 	p.killCalled++
 	return nil
 }
+
+func (p *mockProxy) DumpConfig() error {
+	return nil
+}

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -41,6 +41,7 @@ type ProxyManager interface {
 	Drain() error
 	Quit() error
 	Kill() error
+	DumpConfig() error
 }
 
 // Proxy manages an Envoy proxy process.
@@ -277,6 +278,45 @@ func (p *Proxy) Kill() error {
 	default:
 		return errors.New("proxy must be running to be killed")
 	}
+}
+
+// Dump Envoy config to disk.
+func (p *Proxy) DumpConfig() error {
+	switch p.getState() {
+	case stateExited:
+		return errors.New("proxy must be running to dump config")
+	case stateStopped:
+		return errors.New("proxy must be running to dump config")
+	case stateDraining:
+		return p.dumpConfig()
+	case stateRunning:
+		return p.dumpConfig()
+	default:
+		return errors.New("proxy must be running to dump config")
+	}
+}
+
+func (p *Proxy) dumpConfig() error {
+	envoyConfigDumpUrl := fmt.Sprintf("http://%s:%v/config_dump?include_eds", p.cfg.AdminAddr, p.cfg.AdminBindPort)
+
+	rsp, err := p.client.Get(envoyConfigDumpUrl)
+	if err != nil {
+		p.cfg.Logger.Error("envoy: failed to dump config", "error", err)
+		return err
+	}
+	defer rsp.Body.Close()
+
+	config, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		p.cfg.Logger.Error("envoy: failed to dump config", "error", err)
+		return err
+	}
+
+	if _, err := p.cfg.EnvoyOutputStream.Write(config); err != nil {
+		p.cfg.Logger.Error("envoy: failed to write config to output stream", "error", err)
+	}
+
+	return err
 }
 
 // Exited returns a channel that is closed when the Envoy process exits. It can


### PR DESCRIPTION
Refs https://github.com/hashicorp/consul-k8s/issues/536, https://github.com/hashicorp/consul-k8s/issues/650

<!-- Fixes NET-1781 -->

Changes the SIGINT and SIGTERM handling logic in consul-dataplane to initiate a graceful shutdown of the managed Envoy proxy if configured. Most of the actual implementation of the graceful shutdown logic is in #115 - this PR focuses exclusively  on integrating it into the signal handling and confirming expected behavior through enhancements to the integration test.

Changes should be somewhat reasonable to review by commit if desired.

### Links
- https://golang.testcontainers.org/
- https://pkg.go.dev/github.com/testcontainers/testcontainers-go#Container
- https://pkg.go.dev/github.com/docker/docker/client#NewClientWithOpts
- https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerKill
- https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerStop
- https://pkg.go.dev/os/signal