### PR TITLE
Revert #104 and remove fetch timeout for envoy

### DIFF
--- a/.changelog/131.txt
+++ b/.changelog/131.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Reverts #104 fix that caused a downstream error for Ingress/Mesh/Terminating GWs
+```

--- a/internal/bootstrap/bootstrap_tpl.go
+++ b/internal/bootstrap/bootstrap_tpl.go
@@ -282,12 +282,10 @@ const bootstrapTemplate = `{
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/access-logs.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/access-logs.golden
@@ -157,12 +157,10 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/basic.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/basic.golden
@@ -145,12 +145,10 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/central-telemetry-config.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/central-telemetry-config.golden
@@ -159,12 +159,10 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
@@ -234,12 +234,10 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
@@ -182,12 +182,10 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/ready-listener.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/ready-listener.golden
@@ -234,12 +234,10 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/unix-socket-xds-server.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/unix-socket-xds-server.golden
@@ -144,12 +144,10 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
-      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {


### PR DESCRIPTION
This is reverting a previous fix for an envoy timeout that ended up breaking MGW/TGW/IGW