### PR TITLE
fix(connect): set initial_fetch_time to wait indefinitely

### DIFF
--- a/.changelog/140.txt
+++ b/.changelog/140.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug with Envoy potentially starting with incomplete configuration by not waiting enough for initial xDS configuration.
+```

--- a/internal/bootstrap/bootstrap_tpl.go
+++ b/internal/bootstrap/bootstrap_tpl.go
@@ -282,10 +282,12 @@ const bootstrapTemplate = `{
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/access-logs.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/access-logs.golden
@@ -157,10 +157,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/basic.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/basic.golden
@@ -145,10 +145,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/central-telemetry-config.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/central-telemetry-config.golden
@@ -159,10 +159,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path.golden
@@ -234,10 +234,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
@@ -182,10 +182,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/ready-listener.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/ready-listener.golden
@@ -234,10 +234,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {

--- a/pkg/consuldp/testdata/TestBootstrapConfig/unix-socket-xds-server.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/unix-socket-xds-server.golden
@@ -144,10 +144,12 @@
   "dynamic_resources": {
     "lds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "cds_config": {
       "ads": {},
+      "initial_fetch_timeout": "0s",
       "resource_api_version": "V3"
     },
     "ads_config": {


### PR DESCRIPTION
## Description
Attempt 2 at closing https://github.com/hashicorp/consul/issues/17283

Because we use the default initial_fetch_timeout in the Envoy bootstrap, not all Envoy resources may be loaded in busy systems. However, we previously relied on the timeout to start ingress and API gateways. This PR changes the default initial_fetch_timeout to wait indefinitely "0s".

The Consul PR that updates the snapshot functionality is below.

## Links
[Consul PR](https://github.com/hashicorp/consul/pull/18024)