### PR TITLE
bump to Envoy 1.26.2

### DIFF
--- a/.changelog/142.txt
+++ b/.changelog/142.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update to Envoy 1.26.2 within the Dockerfile. 
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # envoy-binary pulls in the latest Envoy binary, as Envoy don't publish
 # prebuilt binaries in any other form.
-FROM envoyproxy/envoy-distroless:v1.26.1 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.26.2 as envoy-binary
 
 # go-discover builds the discover binary (which we don't currently publish
 # either).


### PR DESCRIPTION
Bump Envoy to 1.26.2 for Consul 1.16.x RC. Associated with the following PR: https://github.com/hashicorp/consul/pull/17546/files