### PR TITLE
Updating go-discover to the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM envoyproxy/envoy-distroless:v1.26.2 as envoy-binary
 # go-discover builds the discover binary (which we don't currently publish
 # either).
 FROM golang:1.20.4-alpine as go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@49f60c093101c9c5f6b04d5b1c80164251a761a6
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 # Pull in dumb-init from alpine, as our distroless release image doesn't have a
 # package manager and there's no RPM package for UBI.


### PR DESCRIPTION
`go-discover` (https://github.com/hashicorp/go-discover) in this container is pinned to a slightly old version (circa September 2022).

To appease container scanners who may find issues in this older binary, I'm proposing that we update to the latest head ref.

Because go-discover does not use semver or have formal releases, there may be a chance this version update breaks existing functionality.