### PR TITLE
Add CRT updates and FIPS envoy image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
           instructions: CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-X github.com/hashicorp/consul-dataplane/pkg/version.GitCommit=${GITHUB_SHA::8}" -o $BIN_PATH ./cmd/$BIN_NAME
 
   build-docker-default:
-    name: Docker ${{ matrix.arch }} default release build
+    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} default release build
     needs:
       - get-product-version
       - build-linux
@@ -172,8 +172,11 @@ jobs:
       matrix:
         # This is the subset of architectures we build binaries for officially
         # supported by Envoy.
-        arch: ["arm64", "amd64"]
-        fips: [ ".fips1402", ""]
+        include:
+          - { arch: "amd64" }
+          - { arch: "amd64", fips: ".fips1402", registry-suffix: "-fips" }
+          - { arch: "arm64" }
+          - { arch: "arm64", fips: ".fips1402", registry-suffix: "-fips" }
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.get-product-version.outputs.product-version }}${{ matrix.fips }}
@@ -188,7 +191,7 @@ jobs:
           version="${{ env.version }}"
           echo "dev_tag=${version%.*}-dev" >> $GITHUB_ENV
 
-      - name: Docker Build (Action)
+      - name: Docker ${{ matrix.fips }} Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
           smoke_test: |
@@ -199,44 +202,51 @@ jobs:
             fi
             echo "Test PASSED"
           version: ${{ env.version }}
-          target: release-default
+          target: release${{ matrix.registry-suffix }}-default
           arch: ${{ matrix.arch }}
           tags: |
-            docker.io/hashicorp/${{env.repo}}:${{env.version}}
-            public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}
+            docker.io/hashicorp/${{env.repo}}${{ matrix.registry-suffix }}:${{env.version}}
+            public.ecr.aws/hashicorp/${{env.repo}}${{ matrix.registry-suffix }}:${{env.version}}
           dev_tags: |
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}-${{ github.sha }}
 
   build-docker-redhat:
-    name: Docker UBI Image Build (for Red Hat Certified Container Registry)
-    needs:
-      - get-product-version
-      - build-linux
-    runs-on: ubuntu-latest
-    env:
-      repo: ${{github.event.repository.name}}
-      version: ${{needs.get-product-version.outputs.product-version}}
-
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: hashicorp/actions-docker-build@v1
-        with:
-          version: ${{env.version}}
-          target: release-ubi
-          arch: amd64
-          redhat_tag: quay.io/redhat-isv-containers/631f805e0d15f623c5996c2e:${{env.version}}-ubi
-
-  build-docker-ubi-dockerhub:
-    name: Docker ${{ matrix.arch }} UBI build for DockerHub
+    name: Docker ${{ matrix.fips }} UBI Image Build (for Red Hat Certified Container Registry)
     needs:
       - get-product-version
       - build-linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["amd64"]
-        fips: [".fips1402", ""]
+        include:
+          - { target-name: "release-ubi", registry-id: "631f805e0d15f623c5996c2e" }
+          - { target-name: "release-fips-ubi", registry-id: "6484fd31685105da62a96b24", fips: ".fips1402" }
+
+    env:
+      repo: ${{github.event.repository.name}}
+      version: ${{needs.get-product-version.outputs.product-version}}${{ matrix.fips }}
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: hashicorp/actions-docker-build@v1
+        with:
+          version: ${{env.version}}
+          target: ${{ matrix.target-name }}
+          arch: amd64
+          redhat_tag: quay.io/redhat-isv-containers/${{matrix.registry-id}}:${{env.version}}-ubi
+
+  build-docker-ubi-dockerhub:
+    name: Docker ${{ matrix.arch }} ${{ matrix.fips }} UBI build for DockerHub
+    needs:
+      - get-product-version
+      - build-linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { arch: "amd64" }
+          - { arch: "amd64", fips: ".fips1402", registry-suffix: "-fips" }
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.get-product-version.outputs.product-version }}${{ matrix.fips }}
@@ -260,14 +270,14 @@ jobs:
             fi
             echo "Test PASSED"
           version: ${{ env.version }}
-          target: release-ubi
+          target: release${{ matrix.registry-suffix }}-ubi
           arch: ${{ matrix.arch }}
           tags: |
-            docker.io/hashicorp/${{env.repo}}:${{env.version}}-ubi
-            public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}-ubi
+            docker.io/hashicorp/${{env.repo}}${{ matrix.registry-suffix }}:${{env.version}}-ubi
+            public.ecr.aws/hashicorp/${{env.repo}}${{ matrix.registry-suffix }}:${{env.version}}-ubi
           dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}-ubi
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}-ubi-${{ github.sha }}
+            docker.io/hashicorppreview/${{ env.repo }}${{ matrix.registry-suffix }}:${{ env.dev_tag }}-ubi
+            docker.io/hashicorppreview/${{ env.repo }}${{ matrix.registty-suffix }}:${{ env.dev_tag }}-ubi-${{ github.sha }}
 
   integration-tests:
     name: Integration Tests (Consul ${{ matrix.server.version }} ${{ matrix.dataplane.docker_target }})

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@
 # prebuilt binaries in any other form.
 FROM envoyproxy/envoy-distroless:v1.26.2 as envoy-binary
 
+FROM hashicorp/envoy-fips:v1.26.2 as envoy-fips-binary
+
 # go-discover builds the discover binary (which we don't currently publish
 # either).
 FROM golang:1.20.4-alpine as go-discover
@@ -51,6 +53,36 @@ USER 100
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
 
+# FIPS release-default release image
+# -----------------------------------
+FROM gcr.io/distroless/base-debian11 AS release-fips-default
+
+ARG BIN_NAME
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+ARG PRODUCT_NAME=$BIN_NAME
+
+# TARGETARCH and TARGETOS are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL name=${BIN_NAME}\
+      maintainer="Consul Team <consul@hashicorp.com>" \
+      vendor="HashiCorp" \
+      version=${PRODUCT_VERSION} \
+      release=${PRODUCT_REVISION} \
+      revision=${PRODUCT_REVISION} \
+      summary="Consul dataplane manages the proxy that runs within the data plane layer of Consul Service Mesh." \
+      description="Consul dataplane manages the proxy that runs within the data plane layer of Consul Service Mesh."
+
+COPY --from=go-discover /go/bin/discover /usr/local/bin/
+COPY --from=envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/
+COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
+
+USER 100
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
+
 # Red Hat UBI-based image
 # This image is based on the Red Hat UBI base image, and has the necessary
 # labels, license file, and non-root user.
@@ -84,6 +116,45 @@ RUN groupadd --gid 1000 $PRODUCT_NAME && \
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
 COPY --from=go-discover /go/bin/discover /usr/local/bin/
 COPY --from=envoy-binary /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
+COPY LICENSE /licenses/copyright.txt
+
+USER 100
+ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
+
+# FIPS Red Hat UBI-based image
+# This image is based on the Red Hat UBI base image, and has the necessary
+# labels, license file, and non-root user.
+# -----------------------------------
+FROM registry.access.redhat.com/ubi9-minimal:9.2 as release-fips-ubi
+
+ARG BIN_NAME
+ENV BIN_NAME=$BIN_NAME
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+ARG PRODUCT_NAME=$BIN_NAME
+# TARGETARCH and TARGETOS are set automatically when --platform is provided.
+ARG TARGETOS TARGETARCH
+
+LABEL name=${BIN_NAME}\
+      maintainer="Consul Team <consul@hashicorp.com>" \
+      vendor="HashiCorp" \
+      version=${PRODUCT_VERSION} \
+      release=${PRODUCT_REVISION} \
+      revision=${PRODUCT_REVISION} \
+      summary="Consul dataplane connects an application to a Consul service mesh." \
+      description="Consul dataplane connects an application to a Consul service mesh."
+
+RUN microdnf install -y shadow-utils
+
+# Create a non-root user to run the software.
+RUN groupadd --gid 1000 $PRODUCT_NAME && \
+    adduser --uid 100 --system -g $PRODUCT_NAME $PRODUCT_NAME && \
+    usermod -a -G root $PRODUCT_NAME
+
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
+COPY --from=go-discover /go/bin/discover /usr/local/bin/
+COPY --from=envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/envoy
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
 COPY LICENSE /licenses/copyright.txt
 


### PR DESCRIPTION
As part of the release process for consul and consul-k8s earlier this week, CRT arrived at the conclusion that a paradigm using separate targets and container repositories for FIPS versions of Consul products was the preferred way to ensure that FIPS and non-FIPS products do not risk overwriting each other in the pipeline. This PR incorporates those changes for Dataplane, similar to what was done in the k8s PR, as well as enterprise (not linked here):
https://github.com/hashicorp/consul-k8s/pull/2333

This PR also updates the FIPS target in Dataplane to use a FIPS Envoy image.