### PR TITLE
Add changelog to release branches

### DIFF
--- a/.changelog/153.txt
+++ b/.changelog/153.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update go-discover to 214571b6a5309addf3db7775f4ee8cf4d264fd5f within the Dockerfile. 
+```


### PR DESCRIPTION
- I couldn't add a changelog to the original go-discover PR because it was a fork.