### PR TITLE
Send the Namespace/Partition as gRPC metadata headers in the request to the Consul DNS service.

### DIFF
--- a/.changelog/172.txt
+++ b/.changelog/172.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+dns: queries proxied by consul-dataplane now assume the same namespace/partition/ACL token as the service registered to the dataplane instance.
+```

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -55,10 +55,9 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 	}
 
 	// store the final resolved service for others to use.
-	cdp.resolvedService = ServiceConfig{
+	cdp.resolvedProxyConfig = ProxyConfig{
 		NodeName:  rsp.NodeName,
-		NodeID:    rsp.NodeId,
-		ServiceID: cdp.cfg.Service.ServiceID,
+		ProxyID:   cdp.cfg.Proxy.ProxyID,
 		Namespace: rsp.Namespace,
 		Partition: rsp.Partition,
 	}

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -54,6 +54,15 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 		return nil, nil, fmt.Errorf("failed to get envoy bootstrap params: %w", err)
 	}
 
+	// store the final resolved service for others to use.
+	cdp.resolvedService = ServiceConfig{
+		NodeName:  rsp.NodeName,
+		NodeID:    rsp.NodeId,
+		ServiceID: cdp.cfg.Service.ServiceID,
+		Namespace: rsp.Namespace,
+		Partition: rsp.Partition,
+	}
+
 	prom := cdp.cfg.Telemetry.Prometheus
 	args := &bootstrap.BootstrapTplArgs{
 		GRPC: bootstrap.GRPC{

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -41,12 +41,13 @@ func TestBootstrapConfig(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		cfg   *Config
-		rsp   *pbdataplane.GetEnvoyBootstrapParamsResponse
-		rspV2 *pbdataplane.GetEnvoyBootstrapParamsResponse
+		cfg                 *Config
+		rsp                 *pbdataplane.GetEnvoyBootstrapParamsResponse
+		rspV2               *pbdataplane.GetEnvoyBootstrapParamsResponse
+		resolvedProxyConfig *ProxyConfig
 	}{
 		"access-logs": {
-			&Config{
+			cfg: &Config{
 				Proxy: &ProxyConfig{
 					ProxyID:  "web-proxy",
 					NodeName: nodeName,
@@ -60,7 +61,7 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Service:  "web",
 				NodeName: nodeName,
 				Config: makeStruct(map[string]any{
@@ -68,7 +69,7 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 				AccessLogs: []string{"{\"name\":\"Consul Listener Filter Log\",\"typedConfig\":{\"@type\":\"type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog\",\"logFormat\":{\"jsonFormat\":{\"custom_field\":\"%START_TIME%\"}}}}"},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Identity: "web",
 				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
@@ -78,7 +79,7 @@ func TestBootstrapConfig(t *testing.T) {
 			},
 		},
 		"basic": {
-			&Config{
+			cfg: &Config{
 				Proxy: &ProxyConfig{
 					ProxyID:  "web-proxy",
 					NodeName: nodeName,
@@ -92,14 +93,14 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Service:  "web",
 				NodeName: nodeName,
 				Config: makeStruct(map[string]any{
 					"envoy_dogstatsd_url": "this-should-not-appear-in-generated-config",
 				}),
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Identity: "web",
 				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
@@ -108,7 +109,7 @@ func TestBootstrapConfig(t *testing.T) {
 			},
 		},
 		"central-telemetry-config": {
-			&Config{
+			cfg: &Config{
 				Proxy: &ProxyConfig{
 					ProxyID:  "web-proxy",
 					NodeName: nodeName,
@@ -122,14 +123,14 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Service:  "web",
 				NodeName: nodeName,
 				Config: makeStruct(map[string]any{
 					"envoy_dogstatsd_url": "udp://127.0.0.1:9125",
 				}),
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Identity: "web",
 				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
@@ -171,7 +172,7 @@ func TestBootstrapConfig(t *testing.T) {
 			},
 		},
 		"custom-prometheus-scrape-path": {
-			&Config{
+			cfg: &Config{
 				Proxy: &ProxyConfig{
 					ProxyID:  "web-proxy",
 					NodeName: nodeName,
@@ -189,14 +190,14 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Service:  "web",
 				NodeName: nodeName,
 				Config: makeStruct(map[string]any{
 					"envoy_prometheus_bind_addr": "0.0.0.0:20200",
 				}),
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Identity: "web",
 				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
@@ -205,7 +206,7 @@ func TestBootstrapConfig(t *testing.T) {
 			},
 		},
 		"custom-prometheus-scrape-path-with-query": {
-			&Config{
+			cfg: &Config{
 				Proxy: &ProxyConfig{
 					ProxyID:  "web-proxy",
 					NodeName: nodeName,
@@ -224,14 +225,14 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Service:  "web",
 				NodeName: nodeName,
 				Config: makeStruct(map[string]any{
 					"envoy_prometheus_bind_addr": "0.0.0.0:20200",
 				}),
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Identity: "web",
 				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
@@ -239,8 +240,50 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 			},
 		},
+		"non-default tenancy": {
+			cfg: &Config{
+				Proxy: &ProxyConfig{
+					ProxyID:  "web-proxy",
+					NodeName: nodeName,
+					// No tenancy provided here to make sure it comes from the bootstrap call
+				},
+				Envoy: &EnvoyConfig{
+					AdminBindAddress: "127.0.0.1",
+					AdminBindPort:    19000,
+				},
+				Telemetry: &TelemetryConfig{
+					UseCentralConfig: false,
+				},
+				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
+			},
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
+				Service:  "web",
+				NodeName: nodeName,
+				Config: makeStruct(map[string]any{
+					"envoy_dogstatsd_url": "this-should-not-appear-in-generated-config",
+				}),
+				Namespace: "test-namespace",
+				Partition: "test-partition",
+			},
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
+				Identity: "web",
+				NodeName: nodeName,
+				BootstrapConfig: &pbmesh.BootstrapConfig{
+					DogstatsdUrl: "this-should-not-appear-in-generated-config",
+				},
+				Namespace: "test-namespace",
+				Partition: "test-partition",
+			},
+			// We want to ensure cdp is configured with the resolved tenancy
+			resolvedProxyConfig: &ProxyConfig{
+				NodeName:  nodeName,
+				ProxyID:   "web-proxy",
+				Namespace: "test-namespace",
+				Partition: "test-partition",
+			},
+		},
 		"ready-listener": {
-			&Config{
+			cfg: &Config{
 				Proxy: &ProxyConfig{
 					ProxyID:  "web-proxy",
 					NodeName: nodeName,
@@ -256,17 +299,17 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 				XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: xdsBindPort},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Service:  "web",
 				NodeName: nodeName,
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Identity: "web",
 				NodeName: nodeName,
 			},
 		},
 		"unix-socket-xds-server": {
-			&Config{
+			cfg: &Config{
 				Proxy: &ProxyConfig{
 					ProxyID:  "web-proxy",
 					NodeName: nodeName,
@@ -280,14 +323,14 @@ func TestBootstrapConfig(t *testing.T) {
 				},
 				XDSServer: &XDSServer{BindAddress: fmt.Sprintf("unix://%s", socketPath)},
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rsp: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Service:  "web",
 				NodeName: nodeName,
 				Config: makeStruct(map[string]any{
 					"envoy_dogstatsd_url": "this-should-not-appear-in-generated-config",
 				}),
 			},
-			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
 				Identity: "web",
 				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
@@ -328,6 +371,10 @@ func TestBootstrapConfig(t *testing.T) {
 
 			golden(t, bsCfg)
 			validateBootstrapConfig(t, bsCfg)
+
+			if tc.resolvedProxyConfig != nil {
+				require.Equal(t, *tc.resolvedProxyConfig, dp.resolvedProxyConfig)
+			}
 		})
 
 		t.Run(desc+"-v2", func(t *testing.T) {
@@ -361,6 +408,10 @@ func TestBootstrapConfig(t *testing.T) {
 
 			golden(t, bsCfg)
 			validateBootstrapConfig(t, bsCfg)
+
+			if tc.resolvedProxyConfig != nil {
+				require.Equal(t, *tc.resolvedProxyConfig, dp.resolvedProxyConfig)
+			}
 		})
 	}
 }

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -48,7 +48,7 @@ type ConsulDataplane struct {
 	metricsConfig   *metricsConfig
 	lifecycleConfig *lifecycleConfig
 
-	resolvedService ServiceConfig
+	resolvedProxyConfig ProxyConfig
 }
 
 // NewConsulDP creates a new instance of ConsulDataplane
@@ -261,8 +261,8 @@ func (cdp *ConsulDataplane) startDNSProxy(ctx context.Context) error {
 		Port:      cdp.cfg.DNSServer.Port,
 		Client:    dnsClientInterface,
 		Logger:    cdp.logger,
-		Partition: cdp.resolvedService.Partition,
-		Namespace: cdp.resolvedService.Namespace,
+		Partition: cdp.resolvedProxyConfig.Partition,
+		Namespace: cdp.resolvedProxyConfig.Namespace,
 		Token:     cdp.aclToken,
 	})
 	if err == dns.ErrServerDisabled {

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -47,6 +47,8 @@ type ConsulDataplane struct {
 	aclToken        string
 	metricsConfig   *metricsConfig
 	lifecycleConfig *lifecycleConfig
+
+	resolvedService ServiceConfig
 }
 
 // NewConsulDP creates a new instance of ConsulDataplane
@@ -255,10 +257,12 @@ func (cdp *ConsulDataplane) startDNSProxy(ctx context.Context) error {
 	dnsClientInterface := pbdns.NewDNSServiceClient(cdp.serverConn)
 
 	dnsServer, err := dns.NewDNSServer(dns.DNSServerParams{
-		BindAddr: cdp.cfg.DNSServer.BindAddr,
-		Port:     cdp.cfg.DNSServer.Port,
-		Client:   dnsClientInterface,
-		Logger:   cdp.logger,
+		BindAddr:  cdp.cfg.DNSServer.BindAddr,
+		Port:      cdp.cfg.DNSServer.Port,
+		Client:    dnsClientInterface,
+		Logger:    cdp.logger,
+		Partition: cdp.resolvedService.Partition,
+		Namespace: cdp.resolvedService.Namespace,
 	})
 	if err == dns.ErrServerDisabled {
 		cdp.logger.Info("dns proxy disabled: configure the Consul DNS port to enable")

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -263,6 +263,7 @@ func (cdp *ConsulDataplane) startDNSProxy(ctx context.Context) error {
 		Logger:    cdp.logger,
 		Partition: cdp.resolvedService.Partition,
 		Namespace: cdp.resolvedService.Namespace,
+		Token:     cdp.aclToken,
 	})
 	if err == dns.ErrServerDisabled {
 		cdp.logger.Info("dns proxy disabled: configure the Consul DNS port to enable")

--- a/pkg/consuldp/testdata/TestBootstrapConfig/non-default_tenancy.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/non-default_tenancy.golden
@@ -1,0 +1,166 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "web",
+    "id": "web-proxy",
+    "metadata": {
+      "node_name": "agentless-node",
+      "namespace": "test-namespace",
+      "partition": "test-partition"
+    }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576
+        }
+      }
+    ]
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "consul-dataplane",
+        "ignore_health_on_host_removal": false,
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "loadAssignment": {
+          "clusterName": "consul-dataplane",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 1234
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "stats_config": {
+    "stats_tags": [
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:([^.]+)\\.)?[^.]+\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.partition"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.([^.]+\\.(?:[^.]+\\.)?([^.]+)\\.external\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.peer"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.(([^.]+)(?:\\.[^.]+)?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream_peered\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.peer"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.([^.]+(?:\\.([^.]+))?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.partition"
+      },
+      {
+        "tag_name": "local_cluster",
+        "fixed_value": "web"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "web"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "test-namespace"
+      },
+      {
+        "tag_name": "consul.source.partition",
+        "fixed_value": "test-partition"
+      }
+    ],
+    "use_all_default_tags": true
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "transport_api_version": "V3",
+      "grpc_services": {
+        "envoy_grpc": {
+          "cluster_name": "consul-dataplane"
+        }
+      }
+    }
+  }
+}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -295,6 +295,12 @@ func (d *DNSServer) proxyTCPAcceptedConn(ctx context.Context, conn net.Conn, cli
 		ctx, done := context.WithTimeout(context.Background(), time.Minute*1)
 		defer done()
 
+		ctx = metadata.AppendToOutgoingContext(ctx,
+			"x-consul-partition", d.partition,
+			"x-consul-namespace", d.namespace,
+			"x-consul-token", d.token,
+		)
+
 		resp, err := client.Query(ctx, req)
 		if err != nil {
 			logger.Error("error resolving consul request", "error", err)

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -34,6 +34,7 @@ type DNSServerParams struct {
 
 	Partition string
 	Namespace string
+	Token     string
 }
 
 // DNSServerInterface is the interface for athe DNSServer
@@ -60,6 +61,7 @@ type DNSServer struct {
 
 	partition string
 	namespace string
+	token     string
 }
 
 // NewDNSServer creates a new DNS proxy server
@@ -77,6 +79,7 @@ func NewDNSServer(p DNSServerParams) (DNSServerInterface, error) {
 	s.logger = p.Logger.Named("dns-proxy")
 	s.partition = p.Partition
 	s.namespace = p.Namespace
+	s.token = p.Token
 	return s, nil
 }
 
@@ -209,6 +212,7 @@ func (d *DNSServer) queryConsulAndRespondUDP(buf []byte, addr net.Addr) {
 	ctx = metadata.AppendToOutgoingContext(ctx,
 		"x-consul-partition", d.partition,
 		"x-consul-namespace", d.namespace,
+		"x-consul-token", d.token,
 	)
 
 	resp, err := d.client.Query(ctx, req)


### PR DESCRIPTION
## Description

By passing along the tenant of the service being proxied we can more intelligently select the correct partition/namespace to use as defaults for DNS.

This also passes along the Consul ACL token as the x-consul-token grpc metadata. Eventually Consul should be able to use this token instead of the servers default token for authorizing access.

## TODO

- [ ] Tests
- [ ] Support for handling this metadata in Consul (other PRs are in the works for that)
- [ ] A review of whether this was the best way to get the tenancy information to the DNS server