### PR TITLE
Do not throw error on exit

### DIFF
--- a/.changelog/175.txt
+++ b/.changelog/175.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug where exiting envoy would inadvertently throw an error
+```

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -223,8 +223,8 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			doneCh <- nil
-		case <-proxy.Exited():
-			doneCh <- nil
+		case err := <-proxy.Exited():
+			doneCh <- err
 		case <-cdp.xdsServerExited():
 			// Initiate graceful shutdown of Envoy, kill if error
 			if err := proxy.Quit(); err != nil {

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -224,7 +224,7 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			doneCh <- nil
 		case <-proxy.Exited():
-			doneCh <- errors.New("envoy proxy exited unexpectedly")
+			doneCh <- nil
 		case <-cdp.xdsServerExited():
 			// Initiate graceful shutdown of Envoy, kill if error
 			if err := proxy.Quit(); err != nil {

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -224,6 +224,9 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			doneCh <- nil
 		case err := <-proxy.Exited():
+			if err != nil {
+				cdp.logger.Error("envoy proxy exited with error", "error", err)
+			}
 			doneCh <- err
 		case <-cdp.xdsServerExited():
 			// Initiate graceful shutdown of Envoy, kill if error

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -182,6 +182,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 			p.cfg.Logger.Error("failed to cleanup boostrap config", "error", err)
 		}
 		p.exitedCh <- err
+		close(p.exitedCh)
 	}()
 
 	return nil

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -56,7 +56,7 @@ type Proxy struct {
 
 	state    state
 	cmd      *exec.Cmd
-	exitedCh chan struct{}
+	exitedCh chan error
 }
 
 // ProxyConfig contains the configuration required to run an Envoy proxy.
@@ -131,7 +131,7 @@ func NewProxy(cfg ProxyConfig) (*Proxy, error) {
 			Timeout: 10 * time.Second,
 		},
 
-		exitedCh: make(chan struct{}),
+		exitedCh: make(chan error),
 	}, nil
 }
 
@@ -181,7 +181,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 		if err := cleanup(); err != nil {
 			p.cfg.Logger.Error("failed to cleanup boostrap config", "error", err)
 		}
-		close(p.exitedCh)
+		p.exitedCh <- errors.New("envoy proxy exited unexpectedly")
 	}()
 
 	return nil
@@ -321,7 +321,7 @@ func (p *Proxy) dumpConfig() error {
 
 // Exited returns a channel that is closed when the Envoy process exits. It can
 // be used to detect and act on process crashes.
-func (p *Proxy) Exited() chan struct{} { return p.exitedCh }
+func (p *Proxy) Exited() chan error { return p.exitedCh }
 
 func (p *Proxy) getState() state {
 	return state(atomic.LoadUint32((*uint32)(&p.state)))

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -181,7 +181,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 		if err := cleanup(); err != nil {
 			p.cfg.Logger.Error("failed to cleanup boostrap config", "error", err)
 		}
-		p.exitedCh <- errors.New("envoy proxy exited unexpectedly")
+		p.exitedCh <- err
 	}()
 
 	return nil


### PR DESCRIPTION
I was testing graceful shutdown and came across a bug that caused kubernetes jobs to fail because consul-dataplane was always throwing an error on exit. With graceful shutdown, envoy exiting is expected.

There might be a better way to do this but we need this fix for the upcoming patches with graceful shutdown going out.

If you look below, envoy is exiting nicely and does exit `consul-dataplane: envoy process exited: error=<nil>` and then we come along and throw an error which causes an incorrect exit code.  

Note: We are still doing a cleanup but the only difference is if we throw an error or not.

Before:

>2023-06-27T02:45:41.336Z+00:00 [info] envoy.main(19) exiting
2023-06-27T02:45:41.336Z+00:00 [debug] envoy.init(19) RunHelper destroyed
2023-06-27T02:45:41.336Z+00:00 [debug] envoy.main(19) destroying listener manager
2023-06-27T02:45:41.337Z+00:00 [debug] envoy.init(19) target LDS destroyed
2023-06-27T02:45:41.337Z+00:00 [debug] envoy.main(19) destroying dispatcher worker_1
2023-06-27T02:45:41.337Z+00:00 [debug] envoy.main(19) destroying dispatcher worker_0
2023-06-27T02:45:41.337Z+00:00 [debug] envoy.init(19) Listener-local-init-watcher public_listener:10.244.0.49:20000 destroyed
2023-06-27T02:45:41.338Z+00:00 [debug] envoy.init(19) init manager Listener-local-init-manager public_listener:10.244.0.49:20000 14451030945282425318 destroyed
2023-06-27T02:45:41.338Z+00:00 [debug] envoy.init(19) target Listener-init-target public_listener:10.244.0.49:20000 destroyed
2023-06-27T02:45:41.338Z+00:00 [debug] envoy.main(19) destroyed listener manager
2023-06-27T02:45:41.339Z+00:00 [debug] envoy.main(19) destroying dispatcher workers_guarddog_thread
2023-06-27T02:45:41.339Z+00:00 [debug] envoy.main(19) destroying dispatcher main_thread_guarddog_thread
2023-06-27T02:45:41.339Z+00:00 [debug] envoy.init(19) init manager RTDS destroyed
2023-06-27T02:45:41.339Z+00:00 [debug] envoy.init(19) RTDS destroyed
2023-06-27T02:45:41.339Z+00:00 [debug] envoy.main(19) destroying access logger /dev/null
2023-06-27T02:45:41.340Z+00:00 [debug] envoy.main(19) destroyed access loggers
2023-06-27T02:45:41.340Z+00:00 [debug] envoy.main(19) destroying dispatcher main_thread
2023-06-27T02:45:41.340Z+00:00 [debug] envoy.init(19) init manager Server destroyed
2023-06-27T02:45:41.363Z [INFO]  consul-dataplane: envoy process exited: error=<nil>
2023-06-27T02:45:41.364Z [INFO]  consul-dataplane.server-connection-manager: stopping
2023-06-27T02:45:41.364Z [DEBUG] consul-dataplane.server-connection-manager: backoff: retry after=564.083542ms
2023-06-27T02:45:41.364Z [DEBUG] consul-dataplane.server-connection-manager: aborting: error="context canceled"
2023/06/27 02:45:41 envoy proxy exited unexpectedly

After:

> 2023-06-27T04:42:52.242Z+00:00 [info] envoy.main(18) exiting
2023-06-27T04:42:52.242Z+00:00 [debug] envoy.init(18) RunHelper destroyed
2023-06-27T04:42:52.242Z+00:00 [debug] envoy.main(18) destroying listener manager
2023-06-27T04:42:52.242Z+00:00 [debug] envoy.init(18) target LDS destroyed
2023-06-27T04:42:52.242Z+00:00 [debug] envoy.main(18) destroying dispatcher worker_1
2023-06-27T04:42:52.242Z+00:00 [debug] envoy.main(18) destroying dispatcher worker_0
2023-06-27T04:42:52.242Z+00:00 [debug] envoy.init(18) Listener-local-init-watcher public_listener:10.244.0.10:20000 destroyed
2023-06-27T04:42:52.243Z+00:00 [debug] envoy.init(18) init manager Listener-local-init-manager public_listener:10.244.0.10:20000 5597487295052545895 destroyed
2023-06-27T04:42:52.243Z+00:00 [debug] envoy.init(18) target Listener-init-target public_listener:10.244.0.10:20000 destroyed
2023-06-27T04:42:52.243Z+00:00 [debug] envoy.main(18) destroyed listener manager
2023-06-27T04:42:52.244Z+00:00 [debug] envoy.main(18) destroying dispatcher workers_guarddog_thread
2023-06-27T04:42:52.245Z+00:00 [debug] envoy.main(18) destroying dispatcher main_thread_guarddog_thread
2023-06-27T04:42:52.245Z+00:00 [debug] envoy.init(18) init manager RTDS destroyed
2023-06-27T04:42:52.245Z+00:00 [debug] envoy.init(18) RTDS destroyed
2023-06-27T04:42:52.246Z+00:00 [debug] envoy.main(18) destroying access logger /dev/null
2023-06-27T04:42:52.246Z+00:00 [debug] envoy.main(18) destroyed access loggers
2023-06-27T04:42:52.246Z+00:00 [debug] envoy.main(18) destroying dispatcher main_thread
2023-06-27T04:42:52.247Z+00:00 [debug] envoy.init(18) init manager Server destroyed
2023-06-27T04:42:52.272Z [INFO]  consul-dataplane: envoy process exited: error=<nil>
2023-06-27T04:42:52.273Z [INFO]  consul-dataplane.server-connection-manager: stopping
2023-06-27T04:42:52.273Z [DEBUG] consul-dataplane.server-connection-manager: backoff: retry after=713.960347ms
2023-06-27T04:42:52.273Z [DEBUG] consul-dataplane.server-connection-manager: aborting: error="context canceled"