### PR TITLE
Backport of proxy-lifecycle: add HTTP Server with endpoints for proxy lifecycle shutdown into release/1.0.x

### DIFF
--- a/.changelog/115.txt
+++ b/.changelog/115.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add HTTP server with configurable port and endpoint path for initiating graceful shutdown.
+```

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -1,18 +1,34 @@
 name: consul-dataplane-checks
-
 on:
   push:
     branches:
-      - main
+    - main
+    - 'release/*.*.x'
   pull_request:
 
 jobs:
+  get-go-version:
+    name: "Determine Go toolchain version"
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Determine Go version
+        id: get-go-version
+        # We use .go-version as our source of truth for current Go
+        # version, because "goenv" can react to it automatically.
+        run: |
+          echo "Building with Go $(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
   unit-tests:
     name: unit-tests
+    needs:
+      - get-go-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: go test ./... -p 1 # disable parallelism to avoid port conflicts from default metrics and lifecycle server configuration
@@ -23,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: make docker
@@ -32,11 +48,13 @@ jobs:
       - run: cd integration-tests && go test -dataplane-image="consul-dataplane/release-default:${{ env.VERSION }}"
   golangci:
     name: lint
+    needs:
+      - get-go-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: "1.20"
-      - uses: actions/checkout@v3
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -3,7 +3,7 @@ name: consul-dataplane-checks
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -14,15 +14,29 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
-      - run: go test ./...
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - run: go test ./... -p 1 # disable parallelism to avoid port conflicts from default metrics and lifecycle server configuration
+  integration-tests:
+    name: integration-tests
+    needs:
+      - get-go-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+      - run: make docker
+      #  Currently the server version below is set to 1.15-dev: integration-tests/main_test.go
+      - run: echo "VERSION=$(make version)" >> $GITHUB_ENV
+      - run: cd integration-tests && go test -dataplane-image="consul-dataplane/release-default:${{ env.VERSION }}"
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: "1.20"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -59,11 +59,13 @@ var (
 	promScrapePath        string
 	promMergePort         int
 
-	adminBindAddr    string
-	adminBindPort    int
-	readyBindAddr    string
-	readyBindPort    int
-	envoyConcurrency int
+	adminBindAddr         string
+	adminBindPort         int
+	readyBindAddr         string
+	readyBindPort         int
+	envoyConcurrency      int
+	envoyDrainTimeSeconds int
+	envoyDrainStrategy    string
 
 	xdsBindAddr string
 	xdsBindPort int
@@ -128,6 +130,8 @@ func init() {
 	StringVar(&readyBindAddr, "envoy-ready-bind-address", "", "DP_ENVOY_READY_BIND_ADDRESS", "The address on which Envoy's readiness probe is available.")
 	IntVar(&readyBindPort, "envoy-ready-bind-port", 0, "DP_ENVOY_READY_BIND_PORT", "The port on which Envoy's readiness probe is available.")
 	IntVar(&envoyConcurrency, "envoy-concurrency", 2, "DP_ENVOY_CONCURRENCY", "The number of worker threads that Envoy uses.")
+	IntVar(&envoyDrainTimeSeconds, "envoy-drain-time-seconds", 30, "DP_ENVOY_DRAIN_TIME", "The time in seconds for which Envoy will drain connections.")
+	StringVar(&envoyDrainStrategy, "envoy-drain-strategy", "immediate", "DP_ENVOY_DRAIN_STRATEGY", "The behaviour of Envoy during the drain sequence. Determines whether all open connections should be encouraged to drain immediately or to increase the percentage gradually as the drain time elapses.")
 
 	StringVar(&xdsBindAddr, "xds-bind-addr", "127.0.0.1", "DP_XDS_BIND_ADDR", "The address on which the Envoy xDS server is available.")
 	IntVar(&xdsBindPort, "xds-bind-port", 0, "DP_XDS_BIND_PORT", "The port on which the Envoy xDS server is available.")
@@ -232,6 +236,8 @@ func main() {
 			ReadyBindAddress:              readyBindAddr,
 			ReadyBindPort:                 readyBindPort,
 			EnvoyConcurrency:              envoyConcurrency,
+			EnvoyDrainTimeSeconds:         envoyDrainTimeSeconds,
+			EnvoyDrainStrategy:            envoyDrainStrategy,
 			ShutdownDrainListenersEnabled: shutdownDrainListenersEnabled,
 			ShutdownGracePeriodSeconds:    shutdownGracePeriodSeconds,
 			GracefulShutdownPath:          gracefulShutdownPath,

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -271,7 +271,20 @@ type EnvoyConfig struct {
 	ReadyBindPort int
 	// EnvoyConcurrency is the envoy concurrency https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-concurrency
 	EnvoyConcurrency int
-	// ShutdownDrainListenersEnabled configures whether to wait for all proxy listeners to drain before terminating the proxy container.
+	// EnvoyDrainTime is the time in seconds for which Envoy will drain connections
+	// during a hot restart, when listeners are modified or removed via LDS, or when
+	// initiated manually via a request to the Envoy admin API.
+	// The Envoy HTTP connection manager filter will add “Connection: close” to HTTP1
+	// requests, send HTTP2 GOAWAY, and terminate connections on request completion
+	// (after the delayed close period).
+	// https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-drain-time-s
+	EnvoyDrainTimeSeconds int
+	// EnvoyDrainStrategy is the behaviour of Envoy during the drain sequence.
+	// Determines whether all open connections should be encouraged to drain
+	// immediately or to increase the percentage gradually as the drain time elapses.
+	// https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-drain-strategy
+	EnvoyDrainStrategy string
+	// ShutdownDrainListenersEnabled configures whether to start draining proxy listeners before terminating the proxy container. Drain time defaults to the value of ShutdownGracePeriodSeconds, but may be set explicitly with EnvoyDrainTimeSeconds.
 	ShutdownDrainListenersEnabled bool
 	// ShutdownGracePeriodSeconds is the amount of time to wait after receiving a SIGTERM before terminating the proxy container.
 	ShutdownGracePeriodSeconds int

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -28,8 +29,9 @@ type xdsServer struct {
 	exitedCh        chan struct{}
 }
 
-type httpGetter interface {
+type httpClient interface {
 	Get(string) (*http.Response, error)
+	Post(string, string, io.Reader) (*http.Response, error)
 }
 
 // ConsulDataplane represents the consul-dataplane process
@@ -41,6 +43,7 @@ type ConsulDataplane struct {
 	xdsServer       *xdsServer
 	aclToken        string
 	metricsConfig   *metricsConfig
+	lifecycleConfig *lifecycleConfig
 }
 
 // NewConsulDP creates a new instance of ConsulDataplane
@@ -206,6 +209,12 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		return err
 	}
 
+	cdp.lifecycleConfig = NewLifecycleConfig(cdp.cfg, proxy)
+	err = cdp.lifecycleConfig.startLifecycleManager(ctx)
+	if err != nil {
+		return err
+	}
+
 	doneCh := make(chan error)
 	go func() {
 		select {
@@ -214,12 +223,25 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		case <-proxy.Exited():
 			doneCh <- errors.New("envoy proxy exited unexpectedly")
 		case <-cdp.xdsServerExited():
-			if err := proxy.Stop(); err != nil {
-				cdp.logger.Error("failed to stop proxy", "error", err)
+			// Initiate graceful shutdown of Envoy, kill if error
+			if err := proxy.Quit(); err != nil {
+				cdp.logger.Error("failed to stop proxy, will attempt to kill", "error", err)
+				if err := proxy.Kill(); err != nil {
+					cdp.logger.Error("failed to kill proxy", "error", err)
+				}
 			}
 			doneCh <- errors.New("xDS server exited unexpectedly")
 		case <-cdp.metricsConfig.metricsServerExited():
 			doneCh <- errors.New("metrics server exited unexpectedly")
+		case <-cdp.lifecycleConfig.lifecycleServerExited():
+			// Initiate graceful shutdown of Envoy, kill if error
+			if err := proxy.Quit(); err != nil {
+				cdp.logger.Error("failed to stop proxy", "error", err)
+				if err := proxy.Kill(); err != nil {
+					cdp.logger.Error("failed to kill proxy", "error", err)
+				}
+			}
+			doneCh <- errors.New("proxy lifecycle management server exited unexpectedly")
 		}
 	}()
 	return <-doneCh
@@ -247,20 +269,33 @@ func (cdp *ConsulDataplane) startDNSProxy(ctx context.Context) error {
 }
 
 func (cdp *ConsulDataplane) envoyProxyConfig(cfg []byte) envoy.ProxyConfig {
-	setConcurrency := true
 	extraArgs := cdp.cfg.Envoy.ExtraArgs
-	// Users could set the concurrency as an extra args. Take that as priority for best ux
-	// experience.
-	for _, v := range extraArgs {
-		if v == "--concurrency" {
-			setConcurrency = false
-		}
+
+	envoyArgs := map[string]interface{}{
+		"--concurrency":    cdp.cfg.Envoy.EnvoyConcurrency,
+		"--drain-time-s":   cdp.cfg.Envoy.EnvoyDrainTimeSeconds,
+		"--drain-strategy": cdp.cfg.Envoy.EnvoyDrainStrategy,
 	}
-	if setConcurrency {
-		extraArgs = append(extraArgs, fmt.Sprintf("--concurrency %v", cdp.cfg.Envoy.EnvoyConcurrency))
+
+	// Users could set the Envoy concurrency, drain time, or drain strategy as
+	// extra args. Prioritize values set in that way over passthrough or defaults
+	// from consul-dataplane.
+	for envoyArg, cdpEnvoyValue := range envoyArgs {
+		for _, v := range extraArgs {
+			// If found in extraArgs, skip setting value from consul-dataplane Envoy
+			// config
+			if v == envoyArg {
+				break
+			}
+		}
+
+		// If not found, append value from consul-dataplane Envoy config to extraArgs
+		extraArgs = append(extraArgs, fmt.Sprintf("%s %v", envoyArg, cdpEnvoyValue))
 	}
 
 	return envoy.ProxyConfig{
+		AdminAddr:       cdp.cfg.Envoy.AdminBindAddress,
+		AdminBindPort:   cdp.cfg.Envoy.AdminBindPort,
 		Logger:          cdp.logger,
 		LogJSON:         cdp.cfg.Logging.LogJSON,
 		BootstrapConfig: cfg,

--- a/pkg/consuldp/lifecycle.go
+++ b/pkg/consuldp/lifecycle.go
@@ -1,0 +1,195 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package consuldp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul-dataplane/pkg/envoy"
+)
+
+const (
+	// defaultLifecycleBindPort is the port which will serve the proxy lifecycle HTTP
+	// endpoints on the loopback interface.
+	defaultLifecycleBindPort = "20300"
+	cdpLifecycleBindAddr     = "127.0.0.1"
+	cdpLifecycleUrl          = "http://" + cdpLifecycleBindAddr
+
+	defaultLifecycleShutdownPath = "/graceful_shutdown"
+)
+
+// lifecycleConfig handles all configuration related to managing the Envoy proxy
+// lifecycle, including exposing management controls via an HTTP server.
+type lifecycleConfig struct {
+	logger hclog.Logger
+
+	// consuldp proxy lifecycle management config
+	shutdownDrainListenersEnabled bool
+	shutdownGracePeriodSeconds    int
+	gracefulPort                  int
+	gracefulShutdownPath          string
+
+	// manager for controlling the Envoy proxy process
+	proxy envoy.ProxyManager
+
+	// consuldp proxy lifecycle management server
+	lifecycleServer *http.Server
+
+	// consuldp proxy lifecycle server control
+	errorExitCh chan struct{}
+	running     bool
+	mu          sync.Mutex
+}
+
+func NewLifecycleConfig(cfg *Config, proxy envoy.ProxyManager) *lifecycleConfig {
+	return &lifecycleConfig{
+		shutdownDrainListenersEnabled: cfg.Envoy.ShutdownDrainListenersEnabled,
+		shutdownGracePeriodSeconds:    cfg.Envoy.ShutdownGracePeriodSeconds,
+		gracefulPort:                  cfg.Envoy.GracefulPort,
+		gracefulShutdownPath:          cfg.Envoy.GracefulShutdownPath,
+
+		proxy: proxy,
+
+		errorExitCh: make(chan struct{}, 1),
+		mu:          sync.Mutex{},
+	}
+}
+
+func (m *lifecycleConfig) startLifecycleManager(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.running {
+		return nil
+	}
+
+	m.logger = hclog.FromContext(ctx).Named("lifecycle")
+	m.running = true
+	go func() {
+		<-ctx.Done()
+		m.stopLifecycleServer()
+	}()
+
+	// Start the server which will expose HTTP endpoints for proxy lifecycle
+	// management control
+	mux := http.NewServeMux()
+
+	// Determine what HTTP endpoint paths to configure for the proxy lifecycle
+	// management server. These can be set as flags.
+	cdpLifecycleShutdownPath := defaultLifecycleShutdownPath
+	if m.gracefulShutdownPath != "" {
+		cdpLifecycleShutdownPath = m.gracefulShutdownPath
+	}
+
+	// Set config to allow introspection of default path for testing
+	m.gracefulShutdownPath = cdpLifecycleShutdownPath
+
+	m.logger.Info(fmt.Sprintf("setting graceful shutdown path: %s\n", cdpLifecycleShutdownPath))
+	mux.HandleFunc(cdpLifecycleShutdownPath, m.gracefulShutdown)
+
+	// Determine what the proxy lifecycle management server bind port is. It can be
+	// set as a flag.
+	cdpLifecycleBindPort := defaultLifecycleBindPort
+	if m.gracefulPort != 0 {
+		cdpLifecycleBindPort = strconv.Itoa(m.gracefulPort)
+	}
+	m.lifecycleServer = &http.Server{
+		Addr:    fmt.Sprintf("%s:%s", cdpLifecycleBindAddr, cdpLifecycleBindPort),
+		Handler: mux,
+	}
+
+	// Start the proxy lifecycle management server
+	go m.startLifecycleServer()
+
+	return nil
+}
+
+// startLifecycleServer starts the main proxy lifecycle management server that
+// exposes HTTP endpoints for proxy lifecycle control.
+func (m *lifecycleConfig) startLifecycleServer() {
+	m.logger.Info("starting proxy lifecycle management server", "address", m.lifecycleServer.Addr)
+	err := m.lifecycleServer.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		m.logger.Error("failed to serve proxy lifecycle management requests", "error", err)
+		close(m.errorExitCh)
+	}
+}
+
+// stopLifecycleServer stops the consul dataplane proxy lifecycle server
+func (m *lifecycleConfig) stopLifecycleServer() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.running = false
+
+	if m.lifecycleServer != nil {
+		m.logger.Info("stopping the lifecycle management server")
+		err := m.lifecycleServer.Close()
+		if err != nil {
+			m.logger.Warn("error while closing lifecycle server", "error", err)
+			close(m.errorExitCh)
+		}
+	}
+}
+
+// lifecycleServerExited is used to signal that the lifecycle server
+// recieved a signal to initiate shutdown.
+func (m *lifecycleConfig) lifecycleServerExited() <-chan struct{} {
+	return m.errorExitCh
+}
+
+// gracefulShutdown blocks until shutdownGracePeriodSeconds seconds have elapsed, and, if
+// configured, will drain inbound connections to Envoy listeners during that time.
+func (m *lifecycleConfig) gracefulShutdown(rw http.ResponseWriter, _ *http.Request) {
+	m.logger.Info("initiating shutdown")
+
+	// Create a context that  will signal a cancel at the specified duration.
+	// TODO: should this use lifecycleManager ctx instead of context.Background?
+	timeout := time.Duration(m.shutdownGracePeriodSeconds) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	m.logger.Info(fmt.Sprintf("waiting %d seconds before terminating dataplane proxy", m.shutdownGracePeriodSeconds))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		// If shutdownDrainListenersEnabled, initiatie graceful shutdown of Envoy.
+		// We want to start draining connections from inbound listeners if
+		// configured, but still allow outbound traffic until gracefulShutdownPeriod
+		// has elapsed to facilitate a graceful application shutdown.
+		if m.shutdownDrainListenersEnabled {
+			err := m.proxy.Drain()
+			if err != nil {
+				m.logger.Warn("error while draining Envoy listeners", "error", err)
+				close(m.errorExitCh)
+			}
+		}
+
+		// Block until context timeout has elapsed
+		<-ctx.Done()
+
+		// Finish graceful shutdown, quit Envoy proxy
+		m.logger.Info("shutdown grace period timeout reached")
+		err := m.proxy.Quit()
+		if err != nil {
+			m.logger.Warn("error while shutting down Envoy", "error", err)
+			close(m.errorExitCh)
+		}
+	}()
+
+	// Wait for context timeout to elapse
+	wg.Wait()
+
+	// Return HTTP 200 Success
+	rw.WriteHeader(http.StatusOK)
+}

--- a/pkg/consuldp/lifecycle_test.go
+++ b/pkg/consuldp/lifecycle_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) HashiCorp, envoyAdminPort.
+// SPDX-License-Identifier: MPL-2.0
+
+package consuldp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	envoyAdminPort = 19000
+	envoyAdminAddr = "127.0.0.1"
+)
+
+func TestLifecycleServerClosed(t *testing.T) {
+	cfg := Config{
+		Envoy: &EnvoyConfig{
+			AdminBindAddress: envoyAdminAddr,
+			AdminBindPort:    envoyAdminPort,
+		},
+	}
+	m := NewLifecycleConfig(&cfg, &mockProxy{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	_ = m.startLifecycleManager(ctx)
+	require.Equal(t, m.running, true)
+	cancel()
+	require.Eventually(t, func() bool {
+		return !m.running
+	}, time.Second*2, time.Second)
+
+}
+
+func TestLifecycleServerEnabled(t *testing.T) {
+	cases := map[string]struct {
+		shutdownDrainListenersEnabled bool
+		shutdownGracePeriodSeconds    int
+		gracefulShutdownPath          string
+		gracefulPort                  int
+	}{
+		// TODO: testing the actual Envoy behavior here such as how open or new
+		// connections are handled should happpen in integration or acceptance tests
+		"connection draining disabled without grace period": {
+			// All inbound and outbound connections are terminated immediately.
+		},
+		"connection draining enabled without grace period": {
+			// This should immediately send "Connection: close" to inbound HTTP1
+			// connections, GOAWAY to inbound HTTP2, and terminate connections on
+			// request completion. Outbound connections should start being rejected
+			// immediately.
+			shutdownDrainListenersEnabled: true,
+		},
+		"connection draining disabled with grace period": {
+			// This should immediately terminate any open inbound connections.
+			// Outbound connections should be allowed until the grace period has
+			// elapsed.
+			shutdownGracePeriodSeconds: 5,
+		},
+		"connection draining enabled with grace period": {
+			// This should immediately send "Connection: close" to inbound HTTP1
+			// connections, GOAWAY to inbound HTTP2, and terminate connections on
+			// request completion.
+			// Outbound connections should be allowed until the grace period has
+			// elapsed, then any remaining open connections should be closed and new
+			// outbound connections should start being rejected until pod termination.
+			shutdownDrainListenersEnabled: true,
+			shutdownGracePeriodSeconds:    5,
+		},
+		"custom graceful shutdown path and port": {
+			shutdownDrainListenersEnabled: true,
+			shutdownGracePeriodSeconds:    5,
+			gracefulShutdownPath:          "/quit-nicely",
+			// TODO: should this be random or use freeport? logic disallows passing
+			// zero value explicitly
+			gracefulPort: 23108,
+		},
+	}
+	for name, c := range cases {
+		c := c
+		log.Printf("config = %v", c)
+
+		t.Run(name, func(t *testing.T) {
+			cfg := Config{
+				Envoy: &EnvoyConfig{
+					AdminBindAddress:              envoyAdminAddr,
+					AdminBindPort:                 envoyAdminPort,
+					ShutdownDrainListenersEnabled: c.shutdownDrainListenersEnabled,
+					ShutdownGracePeriodSeconds:    c.shutdownGracePeriodSeconds,
+					GracefulShutdownPath:          c.gracefulShutdownPath,
+					GracefulPort:                  c.gracefulPort,
+				},
+			}
+			m := NewLifecycleConfig(&cfg, &mockProxy{})
+
+			require.NotNil(t, m)
+			require.NotNil(t, m.proxy)
+			require.NotNil(t, m.errorExitCh)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := m.startLifecycleManager(ctx)
+			require.NoError(t, err)
+
+			// Have consul-dataplane's lifecycle server start on an open port
+			// and figure out what port was used so we can make requests to it.
+			// Conveniently, this seems to wait until the server is ready for requests.
+			portCh := make(chan int, 1)
+			if c.gracefulPort == 0 {
+				m.lifecycleServer.Addr = "127.0.0.1:0"
+			}
+			m.lifecycleServer.BaseContext = func(l net.Listener) context.Context {
+				portCh <- l.Addr().(*net.TCPAddr).Port
+				return context.Background()
+			}
+
+			var port int
+			select {
+			case port = <-portCh:
+			case <-time.After(5 * time.Second):
+			}
+
+			// Check lifecycle server graceful port configuration
+			if c.gracefulPort != 0 {
+				require.Equal(t, c.gracefulPort, port, "failed to set lifecycle server port")
+			} else {
+				require.NotEqual(t, 0, port, "failed to figure out lifecycle server port")
+			}
+			log.Printf("port = %v\n", port)
+
+			// Check lifecycle server graceful shutdown path configuration
+			if c.gracefulShutdownPath != "" {
+				require.Equal(t, m.gracefulShutdownPath, c.gracefulShutdownPath, "failed to set lifecycle server graceful shutdown HTTP endpoint path")
+			}
+
+			// Check lifecycle server graceful shutdown path configuration
+			url := fmt.Sprintf("http://127.0.0.1:%d%s", port, m.gracefulShutdownPath)
+			log.Printf("sending request to %s\n", url)
+
+			resp, err := http.Get(url)
+
+			// Use mock client to check expected method calls to proxy manager
+			if c.shutdownDrainListenersEnabled {
+				require.Equal(t, 1, m.proxy.(*mockProxy).drainCalled, "Proxy.Drain() not called as expected")
+			} else {
+				require.Equal(t, 0, m.proxy.(*mockProxy).drainCalled, "Proxy.Drain() called unexpectedly")
+			}
+
+			require.Equal(t, 1, m.proxy.(*mockProxy).quitCalled, "Proxy.Quit() not called as expected")
+			require.Equal(t, 0, m.proxy.(*mockProxy).killCalled, "Proxy.Kill() called unexpectedly")
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NotNil(t, body)
+		})
+	}
+}
+
+type mockProxy struct {
+	runCalled   int
+	drainCalled int
+	quitCalled  int
+	killCalled  int
+}
+
+func (p *mockProxy) Run(ctx context.Context) error {
+	p.runCalled++
+	return nil
+}
+
+func (p *mockProxy) Drain() error {
+	p.drainCalled++
+	return nil
+}
+
+func (p *mockProxy) Quit() error {
+	p.quitCalled++
+	return nil
+}
+func (p *mockProxy) Kill() error {
+	p.killCalled++
+	return nil
+}

--- a/pkg/consuldp/metrics.go
+++ b/pkg/consuldp/metrics.go
@@ -76,7 +76,7 @@ type metricsConfig struct {
 
 	// merged metrics config
 	promScrapeServer *http.Server // the server that will serve all the merged metrics
-	client           httpGetter   // the client that will scrape the urls
+	client           httpClient   // the client that will scrape the urls
 	urls             []string     // the urls that will be scraped
 
 	// consuldp metrics server

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -220,6 +220,12 @@ func (c *mockClient) Get(url string) (*http.Response, error) {
 	}, nil
 }
 
+func (c *mockClient) Post(url string, contentType string, body io.Reader) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
 func makeFakeMetric(url string) string {
 	return fmt.Sprintf(`fake_metric{url="%s"} 1\n`, url)
 }

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -34,7 +34,7 @@ func TestProxy(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, p.Run(context.Background()))
-	t.Cleanup(func() { _ = p.Stop() })
+	t.Cleanup(func() { _ = p.Kill() })
 
 	// Read the output written by fake-envoy. It might take a while, so poll the
 	// file for a couple of seconds.
@@ -67,8 +67,8 @@ func TestProxy(t *testing.T) {
 	// Check the process is still running.
 	require.NoError(t, p.cmd.Process.Signal(syscall.Signal(0)))
 
-	// Ensure Stop kills and reaps the process.
-	require.NoError(t, p.Stop())
+	// Ensure Kill kills and reaps the process.
+	require.NoError(t, p.Kill())
 
 	require.Eventually(t, func() bool {
 		return p.cmd.Process.Signal(syscall.Signal(0)) == os.ErrProcessDone
@@ -87,7 +87,7 @@ func TestProxy_Crash(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, p.Run(context.Background()))
-	t.Cleanup(func() { _ = p.Stop() })
+	t.Cleanup(func() { _ = p.Kill() })
 
 	// Check the process is running.
 	require.NoError(t, p.cmd.Process.Signal(syscall.Signal(0)))
@@ -101,7 +101,7 @@ func TestProxy_Crash(t *testing.T) {
 		t.Fatal("timeout waiting for Exited channel to be closed")
 	}
 
-	require.Equal(t, stateStopped, p.getState())
+	require.Equal(t, stateExited, p.getState())
 }
 
 func TestProxy_ContextDone(t *testing.T) {
@@ -117,7 +117,7 @@ func TestProxy_ContextDone(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, p.Run(ctx))
-	t.Cleanup(func() { _ = p.Stop() })
+	t.Cleanup(func() { _ = p.Kill() })
 
 	// Check the process is running.
 	require.NoError(t, p.cmd.Process.Signal(syscall.Signal(0)))
@@ -131,7 +131,7 @@ func TestProxy_ContextDone(t *testing.T) {
 		t.Fatal("timeout waiting for Exited channel to be closed")
 	}
 
-	require.Equal(t, stateStopped, p.getState())
+	require.Equal(t, stateExited, p.getState())
 }
 
 func testOutputPath() string {

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -158,7 +158,7 @@ func TestProxy_OverridingLoggerAndExtraArgs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, p.Run(context.Background()))
-	t.Cleanup(func() { _ = p.Stop() })
+	t.Cleanup(func() { _ = p.Kill() })
 
 	// Read the output written by fake-envoy. It might take a while, so poll the
 	// file for a couple of second
@@ -195,7 +195,7 @@ func TestProxy_OverridingLoggerAndExtraArgs(t *testing.T) {
 	require.NoError(t, p.cmd.Process.Signal(syscall.Signal(0)))
 
 	// Ensure Stop kills and reaps the process.
-	require.NoError(t, p.Stop())
+	require.NoError(t, p.Kill())
 
 	require.Eventually(t, func() bool {
 		return p.cmd.Process.Signal(syscall.Signal(0)) == os.ErrProcessDone
@@ -219,7 +219,7 @@ func TestProxy_EnvoyExtraArgs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, p.Run(context.Background()))
-	t.Cleanup(func() { _ = p.Stop() })
+	t.Cleanup(func() { _ = p.Kill() })
 
 	// Read the output written by fake-envoy. It might take a while, so poll the
 	// file for a couple of second
@@ -256,7 +256,7 @@ func TestProxy_EnvoyExtraArgs(t *testing.T) {
 	require.NoError(t, p.cmd.Process.Signal(syscall.Signal(0)))
 
 	// Ensure Stop kills and reaps the process.
-	require.NoError(t, p.Stop())
+	require.NoError(t, p.Kill())
 
 	require.Eventually(t, func() bool {
 		return p.cmd.Process.Signal(syscall.Signal(0)) == os.ErrProcessDone


### PR DESCRIPTION
- Manual backport of #115 