### PR TITLE
Add emit_tags_as_labels setting to envoy metrics service cfg

### DIFF
--- a/.changelog/184.txt
+++ b/.changelog/184.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Add capture group labels from Envoy cluster FQDNs to Envoy exported metric labels
+```

--- a/internal/bootstrap/bootstrap_config.go
+++ b/internal/bootstrap/bootstrap_config.go
@@ -846,7 +846,8 @@ func appendTelemetryCollectorConfig(args *BootstrapTplArgs, telemetryCollectorBi
 			"envoy_grpc": {
 			  "cluster_name": "consul_telemetry_collector_loopback"
 			}
-		  }
+		  },
+		  "emit_tags_as_labels": true
 		}
 	  }`
 

--- a/internal/bootstrap/bootstrap_config_test.go
+++ b/internal/bootstrap/bootstrap_config_test.go
@@ -540,7 +540,8 @@ const (
 		"envoy_grpc": {
 		  "cluster_name": "consul_telemetry_collector_loopback"
 		}
-	  }
+	  },
+	  "emit_tags_as_labels": true
 	}
   }`
 
@@ -639,7 +640,8 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 						"envoy_grpc": {
 						  "cluster_name": "consul_telemetry_collector_loopback"
 						}
-					  }
+					  },
+					  "emit_tags_as_labels": true
 					}
 				  }`,
 				StaticClustersJSON: `{

--- a/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden
@@ -90,7 +90,8 @@
           "envoy_grpc": {
             "cluster_name": "consul_telemetry_collector_loopback"
           }
-        }
+        },
+        "emit_tags_as_labels": true
       }
     }
   ],


### PR DESCRIPTION
This syncs the change from consul for the same: https://github.com/hashicorp/consul/pull/17888

We need this to get envoy service metrics tagged with source and destination service meta. Without it, we get metrics from Envoy that do not have the upstream service name, partition, etc (it's just the FQDN). Eg:

```
cluster_ef15b5b5_consul_telemetry_collector_default_otlp_single_node_cluster_internal_d1779413_9e75_e538_94cc_8a6b0e6a5175_consul_upstream_cx_total
```

I made this by:
1. `make copy-bootstrap-config` sync'ing changes
2. manually updating `pkg/consuldp/testdata/TestBootstrapConfig/hcp-metrics.golden` that I guess isn't sync'ed

### Testing & Reproduction steps

<!--

* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

-->

I made this [change directly to `consul-dataplane`](https://github.com/hashicorp/consul-dataplane/blob/main/internal/bootstrap/bootstrap_config.go#L848), deployed it to a personal Docker Hub repo, and ran `consul-k8s install` with it:

```bash
consul-k8s install -preset cloud -hcp-resource-id "$HCP_RESOURCE_ID" -demo \
    --set="global.enterpriseLicense.secretKey=key" \
    --set="global.enterpriseLicense.secretName=consul-license" \
    --set="global.logLevel=debug" \
    --set="global.imageConsulDataplane=jjtimmons/consul-dataplane:latest" \
    --set="metrics.enableTelemetryCollector=true" \
    --set="peering.enabled=true" \
    --set="server.replicas=3"
```

Checked Prometheus and we're getting all the labels:

> {__name__="http_downstream_rq_active", cluster="josh-test-envoy-emit-tags-labels", consul_source_datacenter="josh-test-envoy-emit-tags-labels", consul_source_namespace="default", consul_source_partition="default", consul_source_service="frontend", consul_upstream_datacenter="josh-test-envoy-emit-tags-labels", consul_upstream_namespace="default", consul_upstream_partition="default", consul_upstream_service="consul-telemetry-collector", envoy_cluster="frontend", envoy_http_conn_manager_prefix="upstream", hcp_internal_id="00000000-e387-6f3e-286b-bc6f1e1b4f84", hcp_organization_id="00000000-06f2-45b3-96ba-e4b0ced62717", hcp_project_id="0000000-0087-4a1b-a9d6-b6030d55ea5c", local_cluster="frontend", namespace="default", node_id="frontend-f74f5f4d4-cw72z-frontend-sidecar-proxy", partition="default"}

### Links

Envoy docs: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/metrics/v3/metrics_service.proto

> If true, metrics will have their tags emitted as labels on the metrics objects sent to the MetricsService, and the tag extracted name will be used instead of the full name, which may contain values used by the tag extractor or additional tags added during stats creation.