### PR TITLE
Backport of proxy-lifecycle: catch SIGTERM and initiate graceful shutdown into release/1.0.x (#130)

### DIFF
--- a/.changelog/130.txt
+++ b/.changelog/130.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Catch SIGTERM and SIGINT to initate graceful shutdown in accordance with proxy lifecycle management configuration.
+```

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ else
 	$(error Cannot generate changelog without LAST_RELEASE_GIT_TAG)
 endif
 
-INTEGRATION_TESTS_SERVER_IMAGE    ?= hashicorppreview/consul:1.14-dev
+INTEGRATION_TESTS_SERVER_IMAGE    ?= hashicorppreview/consul:1.15-dev
 INTEGRATION_TESTS_DATAPLANE_IMAGE ?= $(PRODUCT_NAME)/release-default:$(VERSION)
 
 .PHONY: expand-integration-tests-output-dir

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ else
 	$(error Cannot generate changelog without LAST_RELEASE_GIT_TAG)
 endif
 
-INTEGRATION_TESTS_SERVER_IMAGE    ?= hashicorppreview/consul:1.15-dev
+INTEGRATION_TESTS_SERVER_IMAGE    ?= hashicorppreview/consul:1.14-dev
 INTEGRATION_TESTS_DATAPLANE_IMAGE ?= $(PRODUCT_NAME)/release-default:$(VERSION)
 
 .PHONY: expand-integration-tests-output-dir

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -77,6 +77,8 @@ var (
 	shutdownGracePeriodSeconds    int
 	gracefulShutdownPath          string
 	gracefulPort                  int
+
+	dumpEnvoyConfigOnExitEnabled bool
 )
 
 func init() {
@@ -154,6 +156,9 @@ func init() {
 	IntVar(&shutdownGracePeriodSeconds, "shutdown-grace-period-seconds", 0, "DP_SHUTDOWN_GRACE_PERIOD_SECONDS", "Amount of time to wait after receiving a SIGTERM signal before terminating the proxy.")
 	StringVar(&gracefulShutdownPath, "graceful-shutdown-path", "/graceful_shutdown", "DP_GRACEFUL_SHUTDOWN_PATH", "An HTTP path to serve the graceful shutdown endpoint.")
 	IntVar(&gracefulPort, "graceful-port", 20300, "DP_GRACEFUL_PORT", "A port to serve HTTP endpoints for graceful shutdown.")
+
+	// Default is false, may be useful for debugging unexpected termination.
+	BoolVar(&dumpEnvoyConfigOnExitEnabled, "dump-envoy-config-on-exit", false, "DP_DUMP_ENVOY_CONFIG_ON_EXIT", "Call the Envoy /config_dump endpoint during consul-dataplane controlled shutdown.")
 }
 
 // validateFlags performs semantic validation of the flag values
@@ -165,13 +170,13 @@ func validateFlags() {
 	}
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	if printVersion {
 		fmt.Printf("Consul Dataplane v%s\n", version.GetHumanVersion())
 		fmt.Printf("Revision %s\n", version.GitCommit)
-		return
+		return nil
 	}
 
 	readServiceIDFromFile()
@@ -242,6 +247,7 @@ func main() {
 			ShutdownGracePeriodSeconds:    shutdownGracePeriodSeconds,
 			GracefulShutdownPath:          gracefulShutdownPath,
 			GracefulPort:                  gracefulPort,
+			DumpEnvoyConfigOnExitEnabled:  dumpEnvoyConfigOnExitEnabled,
 			ExtraArgs:                     flag.Args(),
 		},
 		XDSServer: &consuldp.XDSServer{
@@ -256,22 +262,28 @@ func main() {
 
 	consuldpInstance, err := consuldp.NewConsulDP(consuldpCfg)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
+		// Block waiting for SIGTERM
 		<-sigCh
-		cancel()
+
+		consuldpInstance.GracefulShutdown(cancel)
 	}()
 
-	err = consuldpInstance.Run(ctx)
+	return consuldpInstance.Run(ctx)
+}
+
+func main() {
+	err := run()
 	if err != nil {
-		cancel()
 		log.Fatal(err)
 	}
 }

--- a/integration-tests/helpers/dataplane.go
+++ b/integration-tests/helpers/dataplane.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -13,13 +12,16 @@ import (
 var EnvoyAdminPort = TCP(30000)
 
 type DataplaneConfig struct {
-	Addresses         string
-	ServiceNodeName   string
-	ProxyServiceID    string
-	LoginAuthMethod   string
-	LoginBearerToken  string
-	DNSBindPort       string
-	ServiceMetricsURL string
+	Addresses                     string
+	ServiceNodeName               string
+	ProxyServiceID                string
+	LoginAuthMethod               string
+	LoginBearerToken              string
+	DNSBindPort                   string
+	ServiceMetricsURL             string
+	ShutdownGracePeriodSeconds    string
+	ShutdownDrainListenersEnabled bool
+	DumpEnvoyConfigOnExitEnabled  bool
 }
 
 func (cfg DataplaneConfig) ToArgs() []string {
@@ -40,6 +42,19 @@ func (cfg DataplaneConfig) ToArgs() []string {
 		"-telemetry-prom-scrape-path", "/metrics",
 		"-telemetry-prom-service-metrics-url", cfg.ServiceMetricsURL,
 	}
+
+	if cfg.ShutdownGracePeriodSeconds != "" {
+		args = append(args, "-shutdown-grace-period-seconds", cfg.ShutdownGracePeriodSeconds)
+	}
+
+	if cfg.ShutdownDrainListenersEnabled {
+		args = append(args, "-shutdown-drain-listeners")
+	}
+
+	if cfg.DumpEnvoyConfigOnExitEnabled {
+		args = append(args, "-dump-envoy-config-on-exit")
+	}
+
 	return args
 }
 
@@ -58,31 +73,6 @@ func RunDataplane(t *testing.T, pod *Pod, suite *Suite, cfg DataplaneConfig) *Co
 			testcontainers.VolumeMount(volume.Name, "/data"),
 		},
 		WaitingFor: wait.ForLog("starting main dispatch loop"), // https://github.com/envoyproxy/envoy/blob/ce49966ecb5f2d530117a29ae60b88198746fd74/source/server/server.cc#L906-L907
-	})
-
-	t.Cleanup(func() {
-		url := fmt.Sprintf(
-			"http://%s:%d/config_dump?include_eds",
-			pod.HostIP,
-			pod.MappedPorts[EnvoyAdminPort],
-		)
-
-		rsp, err := httpClient.Get(url)
-		if err != nil {
-			t.Logf("failed to dump Envoy config: %v\n", err)
-			return
-		}
-		defer rsp.Body.Close()
-
-		config, err := io.ReadAll(rsp.Body)
-		if err != nil {
-			t.Logf("failed to dump Envoy config: %v\n", err)
-			return
-		}
-		suite.CaptureArtifact(
-			fmt.Sprintf("%s-envoy-config.json", cfg.ProxyServiceID),
-			config,
-		)
 	})
 
 	return container

--- a/integration-tests/helpers/suite.go
+++ b/integration-tests/helpers/suite.go
@@ -195,11 +195,17 @@ func (s *Suite) Volume(t *testing.T) *Volume {
 		require.NoError(t, err)
 
 		t.Cleanup(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+			s.mu.Lock()
+			defer s.mu.Unlock()
 
-			if err := docker.VolumeRemove(ctx, v.Name, true); err != nil {
-				t.Logf("failed to remove volume: %v", err)
+			if s.volume != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				if err := docker.VolumeRemove(ctx, v.Name, true); err != nil {
+					t.Logf("failed to remove volume: %v", err)
+				}
+				s.volume = nil
 			}
 		})
 

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -1,15 +1,20 @@
 package integrationtests
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
 
 	"github.com/hashicorp/consul/api"
 
@@ -17,12 +22,12 @@ import (
 )
 
 var (
-	// upstreamLocalBindPort is the port the frontend sidecar will bind the local
-	// listener for its backend upstream to.
+	// upstreamLocalBindPort is the port each sidecar will bind the local
+	// listener for its upstream to.
 	upstreamLocalBindPort = TCP(10000)
 
 	// proxyInboundListenerPort is the port the sidecars will bind their public
-	// listeners to. Only the backend sidecar's public port is used in these tests.
+	// listeners to.
 	proxyInboundListenerPort = TCP(20000)
 
 	// dnsUDPPort is UDP the port Consul Dataplane's DNS proxy wil be bound to.
@@ -59,22 +64,22 @@ func TestMain(m *testing.M) {
 
 // TestIntegration covers the end-to-end service mesh flow by:
 //
-//	* Running a Consul server with TLS and ACLs enabled.
-//	* Creating a JWT ACL auth-method.
-//	* Registering two services and sidecars ("frontend" and "backend") with an
-//	  upstream relationship.
-//	* Running a simple HTTP server for the "backend" service.
-//	* Running consul-datplane for each sidecar, with the "frontend" sidecar's
-//	  local listener port for its "backend" upstream exposed to the host.
-//	* Creating proxy-defaults to set the default protocol to HTTP and prometheus
-//	  bind address.
-//	* Creating an L7/HTTP intention to allow "frontend" to talk to "backend".
-//	* Making an HTTP request through the "frontend" sidecar's exposed "backend"
-//	  port.
-//	* Setting the intention action to deny.
-//	* Attempting to make the same request and checking that it fails.
-//	* Making DNS queries against the frontend dataplane's UDP and TCP DNS proxies.
-//	* Scraping the prometheus merged metrics endpoint.
+//   - Running a Consul server with TLS and ACLs enabled.
+//   - Creating a JWT ACL auth-method.
+//   - Registering two services and sidecars ("frontend" and "backend") with an
+//     upstream relationship.
+//   - Running a simple HTTP server for the "backend" service.
+//   - Running consul-datplane for each sidecar, with the "frontend" sidecar's
+//     local listener port for its "backend" upstream exposed to the host.
+//   - Creating proxy-defaults to set the default protocol to HTTP and prometheus
+//     bind address.
+//   - Creating an L7/HTTP intention to allow "frontend" to talk to "backend".
+//   - Making an HTTP request through the "frontend" sidecar's exposed "backend"
+//     port.
+//   - Setting the intention action to deny.
+//   - Attempting to make the same request and checking that it fails.
+//   - Making DNS queries against the frontend dataplane's UDP and TCP DNS proxies.
+//   - Scraping the prometheus merged metrics endpoint.
 func TestIntegration(t *testing.T) {
 	suite := NewSuite(t, opts)
 
@@ -94,14 +99,15 @@ func TestIntegration(t *testing.T) {
 
 	server.RegisterSyntheticNode(t)
 
+	backendPod := RunPod(t, suite, "backend", []nat.Port{
+		EnvoyAdminPort,
+		upstreamLocalBindPort,
+		metricsPort,
+	})
+
 	server.RegisterService(t, &api.AgentService{
 		Service: "backend",
 		Port:    8080,
-	})
-
-	backendPod := RunPod(t, suite, "backend", []nat.Port{
-		EnvoyAdminPort,
-		metricsPort,
 	})
 
 	server.RegisterService(t, &api.AgentService{
@@ -112,19 +118,28 @@ func TestIntegration(t *testing.T) {
 		Proxy: &api.AgentServiceConnectProxyConfig{
 			DestinationServiceName: "backend",
 			LocalServicePort:       8080,
+			Upstreams: []api.Upstream{
+				{
+					DestinationType:  api.UpstreamDestTypeService,
+					DestinationName:  "frontend",
+					LocalBindPort:    upstreamLocalBindPort.Int(),
+					LocalBindAddress: "0.0.0.0",
+				},
+			},
 		},
 	})
 
 	RunService(t, suite, backendPod, "backend")
 
-	RunDataplane(t, backendPod, suite, DataplaneConfig{
-		Addresses:         server.Container.ContainerIP,
-		ServiceNodeName:   SyntheticNodeName,
-		ProxyServiceID:    "backend-sidecar",
-		LoginAuthMethod:   authMethod.Name,
-		LoginBearerToken:  authMethod.GenerateToken(t, "backend"),
-		DNSBindPort:       dnsUDPPort.Port(),
-		ServiceMetricsURL: "http://localhost:8080",
+	backendDataplane := RunDataplane(t, backendPod, suite, DataplaneConfig{
+		Addresses:                    server.Container.ContainerIP,
+		ServiceNodeName:              SyntheticNodeName,
+		ProxyServiceID:               "backend-sidecar",
+		LoginAuthMethod:              authMethod.Name,
+		LoginBearerToken:             authMethod.GenerateToken(t, "backend"),
+		DNSBindPort:                  dnsUDPPort.Port(),
+		ServiceMetricsURL:            "http://localhost:8080",
+		DumpEnvoyConfigOnExitEnabled: true,
 	})
 
 	frontendPod := RunPod(t, suite, "frontend", []nat.Port{
@@ -146,6 +161,7 @@ func TestIntegration(t *testing.T) {
 		Address: frontendPod.ContainerIP,
 		Proxy: &api.AgentServiceConnectProxyConfig{
 			DestinationServiceName: "frontend",
+			LocalServicePort:       8080,
 			Upstreams: []api.Upstream{
 				{
 					DestinationType:  api.UpstreamDestTypeService,
@@ -157,15 +173,31 @@ func TestIntegration(t *testing.T) {
 		},
 	})
 
-	RunDataplane(t, frontendPod, suite, DataplaneConfig{
-		Addresses:         server.Container.ContainerIP,
-		ServiceNodeName:   SyntheticNodeName,
-		ProxyServiceID:    "frontend-sidecar",
-		LoginAuthMethod:   authMethod.Name,
-		LoginBearerToken:  authMethod.GenerateToken(t, "frontend"),
-		DNSBindPort:       dnsUDPPort.Port(),
-		ServiceMetricsURL: "http://localhost:8080",
+	RunService(t, suite, frontendPod, "frontend")
+
+	frontendDataplane := RunDataplane(t, frontendPod, suite, DataplaneConfig{
+		Addresses:                     server.Container.ContainerIP,
+		ServiceNodeName:               SyntheticNodeName,
+		ProxyServiceID:                "frontend-sidecar",
+		LoginAuthMethod:               authMethod.Name,
+		LoginBearerToken:              authMethod.GenerateToken(t, "frontend"),
+		DNSBindPort:                   dnsUDPPort.Port(),
+		ServiceMetricsURL:             "http://localhost:8080",
+		ShutdownGracePeriodSeconds:    "10",
+		ShutdownDrainListenersEnabled: true,
+		DumpEnvoyConfigOnExitEnabled:  true,
 	})
+
+	// Intentions are configured as default deny in helpers/server.go
+	ExpectNoHTTPAccess(t,
+		frontendPod.HostIP,
+		frontendPod.MappedPorts[upstreamLocalBindPort],
+	)
+
+	ExpectNoHTTPAccess(t,
+		backendPod.HostIP,
+		backendPod.MappedPorts[upstreamLocalBindPort],
+	)
 
 	server.SetConfigEntry(t, &api.ServiceIntentionsConfigEntry{
 		Kind: api.ServiceIntentions,
@@ -230,4 +262,94 @@ func TestIntegration(t *testing.T) {
 	require.Contains(t, metrics, "consul_dataplane_go_goroutines")
 	require.Contains(t, metrics, "envoy_server_total_connections")
 	require.Contains(t, metrics, `service_metric{service_name="backend"}`)
+
+	// Test access logs (Consul 1.15 or greater)
+	if semver.Compare(semver.MajorMinor(opts.ServerVersion), "v1.15") >= 0 {
+		GetEnvoyClusters(t, backendPod.HostIP, backendPod.MappedPorts[EnvoyAdminPort])
+		require.Eventuallyf(t, func() bool {
+			output := backendDataplane.ContainerLogs(t)
+			return strings.Contains(output, "{\"custom_field_path\":\"/clusters\"}")
+		}, 30*time.Second, 3*time.Second, "could not find admin access logs in output")
+	}
+
+	// Overwrite deny intention and allow two-way connections to prepare for
+	// testing graceful shutdown
+	server.SetConfigEntry(t, &api.ServiceIntentionsConfigEntry{
+		Kind: api.ServiceIntentions,
+		Name: "backend",
+		Sources: []*api.SourceIntention{
+			{
+				Name: "frontend",
+				Type: api.IntentionSourceConsul,
+				Permissions: []*api.IntentionPermission{
+					{
+						Action: api.IntentionActionAllow,
+						HTTP: &api.IntentionHTTPPermission{
+							PathPrefix: "/",
+							Methods:    []string{http.MethodGet},
+						},
+					},
+				},
+			},
+		},
+	})
+	server.SetConfigEntry(t, &api.ServiceIntentionsConfigEntry{
+		Kind: api.ServiceIntentions,
+		Name: "frontend",
+		Sources: []*api.SourceIntention{
+			{
+				Name: "backend",
+				Type: api.IntentionSourceConsul,
+				Permissions: []*api.IntentionPermission{
+					{
+						Action: api.IntentionActionAllow,
+						HTTP: &api.IntentionHTTPPermission{
+							PathPrefix: "/",
+							Methods:    []string{http.MethodGet},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// Ensure frontend upstream on backend service is working
+	ExpectHTTPAccess(t,
+		backendPod.HostIP,
+		backendPod.MappedPorts[upstreamLocalBindPort],
+	)
+
+	// Send SIGTERM to dataplane to start graceful shutdown
+	containerID := frontendDataplane.Container.GetContainerID()
+	cli, err := client.NewClientWithOpts(
+		client.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error initializing docker client: %s\n", err)
+		os.Exit(1)
+	}
+	err = cli.ContainerKill(context.Background(), containerID, "SIGTERM")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error killing docker container %s: %s\n", containerID, err)
+		os.Exit(1)
+	}
+	// TODO: It may be preferrable to use ContainerStop to set a longer
+	// StopTimeout to avoid issues with cleanup, but importing the
+	// docker/docker/container package for StopOptions has dependency issues.
+	// https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerStop
+	// err = cli.ContainerStop(context.Background(), containerID, container.StopOptions{})
+
+	// Expect outgoing connections through sidecar are allowed until shutdown
+	// grace period has elapsed.
+	ExpectHTTPAccess(t,
+		frontendPod.HostIP,
+		frontendPod.MappedPorts[upstreamLocalBindPort],
+	)
+
+	// Expect inbound connections to the frontend service are rejected while it
+	// is shutting down if listener draining is configured.
+	ExpectNoHTTPAccess(t,
+		backendPod.HostIP,
+		backendPod.MappedPorts[upstreamLocalBindPort],
+	)
 }

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -292,6 +292,8 @@ type EnvoyConfig struct {
 	GracefulShutdownPath string
 	// GracefulPort is the port on which the HTTP server for graceful shutdown endpoints will be available.
 	GracefulPort int
+	// DumpEnvoyConfigOnExitEnabled configures whether to call Envoy's /config_dump endpoint during consul-dataplane controlled shutdown.
+	DumpEnvoyConfigOnExitEnabled bool
 	// ExtraArgs are the extra arguments passed to envoy at startup of the proxy
 	ExtraArgs []string
 }

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -302,3 +302,13 @@ func (cdp *ConsulDataplane) envoyProxyConfig(cfg []byte) envoy.ProxyConfig {
 		ExtraArgs:       extraArgs,
 	}
 }
+
+func (cdp *ConsulDataplane) GracefulShutdown(cancel context.CancelFunc) {
+	// If proxy lifecycle manager has not been initialized, cancel parent context and
+	// proceed to exit rather than attempting graceful shutdown
+	if cdp.lifecycleConfig != nil {
+		cdp.lifecycleConfig.gracefulShutdown()
+	} else {
+		cancel()
+	}
+}

--- a/pkg/consuldp/lifecycle.go
+++ b/pkg/consuldp/lifecycle.go
@@ -167,15 +167,6 @@ func (m *lifecycleConfig) gracefulShutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	if m.dumpEnvoyConfigOnExitEnabled {
-		m.logger.Info("dumping Envoy config to disk")
-		err := m.proxy.DumpConfig()
-		if err != nil {
-			m.logger.Warn("error while attempting to dump Envoy config to disk", "error", err)
-			close(m.errorExitCh)
-		}
-	}
-
 	m.logger.Info(fmt.Sprintf("waiting %d seconds before terminating dataplane proxy", m.shutdownGracePeriodSeconds))
 
 	var wg sync.WaitGroup

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -38,6 +38,7 @@ type ProxyManager interface {
 	Drain() error
 	Quit() error
 	Kill() error
+	DumpConfig() error
 }
 
 // Proxy manages an Envoy proxy process.
@@ -142,6 +143,14 @@ func (p *Proxy) Run(ctx context.Context) error {
 
 	// Run the Envoy process.
 	p.cmd = p.buildCommand(ctx, configPath)
+
+	// Start Envoy in its own process group to avoid directly receiving
+	// SIGTERM intended for consul-dataplane, let proxy manager handle
+	// graceful shutdown if configured.
+	p.cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
 	p.cfg.Logger.Debug("running envoy proxy", "command", strings.Join(p.cmd.Args, " "))
 	if err := p.cmd.Start(); err != nil {
 		// Clean up the pipe if we weren't able to run Envoy.
@@ -258,6 +267,45 @@ func (p *Proxy) Kill() error {
 	default:
 		return errors.New("proxy must be running to be killed")
 	}
+}
+
+// Dump Envoy config to disk.
+func (p *Proxy) DumpConfig() error {
+	switch p.getState() {
+	case stateExited:
+		return errors.New("proxy must be running to dump config")
+	case stateStopped:
+		return errors.New("proxy must be running to dump config")
+	case stateDraining:
+		return p.dumpConfig()
+	case stateRunning:
+		return p.dumpConfig()
+	default:
+		return errors.New("proxy must be running to dump config")
+	}
+}
+
+func (p *Proxy) dumpConfig() error {
+	envoyConfigDumpUrl := fmt.Sprintf("http://%s:%v/config_dump?include_eds", p.cfg.AdminAddr, p.cfg.AdminBindPort)
+
+	rsp, err := p.client.Get(envoyConfigDumpUrl)
+	if err != nil {
+		p.cfg.Logger.Error("envoy: failed to dump config", "error", err)
+		return err
+	}
+	defer rsp.Body.Close()
+
+	config, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		p.cfg.Logger.Error("envoy: failed to dump config", "error", err)
+		return err
+	}
+
+	if _, err := p.cfg.EnvoyOutputStream.Write(config); err != nil {
+		p.cfg.Logger.Error("envoy: failed to write config to output stream", "error", err)
+	}
+
+	return err
 }
 
 // Exited returns a channel that is closed when the Envoy process exits. It can

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -38,7 +38,6 @@ type ProxyManager interface {
 	Drain() error
 	Quit() error
 	Kill() error
-	DumpConfig() error
 }
 
 // Proxy manages an Envoy proxy process.
@@ -267,45 +266,6 @@ func (p *Proxy) Kill() error {
 	default:
 		return errors.New("proxy must be running to be killed")
 	}
-}
-
-// Dump Envoy config to disk.
-func (p *Proxy) DumpConfig() error {
-	switch p.getState() {
-	case stateExited:
-		return errors.New("proxy must be running to dump config")
-	case stateStopped:
-		return errors.New("proxy must be running to dump config")
-	case stateDraining:
-		return p.dumpConfig()
-	case stateRunning:
-		return p.dumpConfig()
-	default:
-		return errors.New("proxy must be running to dump config")
-	}
-}
-
-func (p *Proxy) dumpConfig() error {
-	envoyConfigDumpUrl := fmt.Sprintf("http://%s:%v/config_dump?include_eds", p.cfg.AdminAddr, p.cfg.AdminBindPort)
-
-	rsp, err := p.client.Get(envoyConfigDumpUrl)
-	if err != nil {
-		p.cfg.Logger.Error("envoy: failed to dump config", "error", err)
-		return err
-	}
-	defer rsp.Body.Close()
-
-	config, err := io.ReadAll(rsp.Body)
-	if err != nil {
-		p.cfg.Logger.Error("envoy: failed to dump config", "error", err)
-		return err
-	}
-
-	if _, err := p.cfg.EnvoyOutputStream.Write(config); err != nil {
-		p.cfg.Logger.Error("envoy: failed to write config to output stream", "error", err)
-	}
-
-	return err
 }
 
 // Exited returns a channel that is closed when the Envoy process exits. It can


### PR DESCRIPTION
- Manual backport of #130 into release/1.0.x