### PR TITLE
[NET-4904] security: update Envoy to 1.26.4

### DIFF
--- a/.changelog/235.txt
+++ b/.changelog/235.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update to Go 1.20.7 and Envoy 1.26.4 within the Dockerfile. 
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,14 @@
 
 # envoy-binary pulls in the latest Envoy binary, as Envoy don't publish
 # prebuilt binaries in any other form.
-FROM envoyproxy/envoy-distroless:v1.26.2 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.26.4 as envoy-binary
 
+# TODO once hashicorp/envoy-fips:v1.26.4 is published this should be updated as well
 FROM hashicorp/envoy-fips:v1.26.2 as envoy-fips-binary
 
 # go-discover builds the discover binary (which we don't currently publish
 # either).
-FROM golang:1.20.4-alpine as go-discover
+FROM golang:1.20.7-alpine as go-discover
 RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@214571b6a5309addf3db7775f4ee8cf4d264fd5f
 
 # Pull in dumb-init from alpine, as our distroless release image doesn't have a


### PR DESCRIPTION
Also update Go to 1.20.7 in the Dockerfile. It was updated in CI as part of https://github.com/hashicorp/consul-dataplane/pull/227.

1.1.x PR: https://github.com/hashicorp/consul-dataplane/pull/236
1.0.x PR: https://github.com/hashicorp/consul-dataplane/pull/237