### PR TITLE
NET-5186 Allow dataplane container to bind to privileged ports

### DIFF
--- a/.changelog/238.txt
+++ b/.changelog/238.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug where container user was unable to bind to privileged ports (< 1024). The consul-dataplane container now requires the NET_BIND_SERVICE capability.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,18 @@ FROM envoyproxy/envoy-distroless:v1.26.4 as envoy-binary
 FROM hashicorp/envoy-fips:v1.26.2 as envoy-fips-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024)
-FROM alpine:latest AS envoy-setcap
+FROM alpine:latest AS setcap
 
-ARG BIN_NAME
+ARG BIN_NAME=consul-dataplane
 ARG TARGETARCH
 ARG TARGETOS
 
 COPY --from=envoy-binary /usr/local/bin/envoy /usr/local/bin/
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
 
 RUN apk add libcap
-RUN setcap cap_net_bind_service+ep /usr/local/bin/envoy
+RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/envoy
+RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/$BIN_NAME
 
 # go-discover builds the discover binary (which we don't currently publish
 # either).
@@ -40,7 +42,8 @@ RUN apk add dumb-init
 # -----------------------------------
 FROM gcr.io/distroless/base-debian11 AS release-default
 
-ARG BIN_NAME
+ARG BIN_NAME=consul-dataplane
+ENV BIN_NAME=$BIN_NAME
 ARG PRODUCT_VERSION
 ARG PRODUCT_REVISION
 ARG PRODUCT_NAME=$BIN_NAME
@@ -57,10 +60,10 @@ LABEL name=${BIN_NAME}\
       summary="Consul dataplane manages the proxy that runs within the data plane layer of Consul Service Mesh." \
       description="Consul dataplane manages the proxy that runs within the data plane layer of Consul Service Mesh."
 
-COPY --from=go-discover /go/bin/discover /usr/local/bin/
-COPY --from=envoy-setcap /usr/local/bin/envoy /usr/local/bin/
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
-COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
+COPY --from=go-discover /go/bin/discover /usr/local/bin/
+COPY --from=setcap /usr/local/bin/envoy /usr/local/bin/
+COPY --from=setcap /usr/local/bin/$BIN_NAME /usr/local/bin/
 
 USER 100
 
@@ -102,7 +105,7 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
 # -----------------------------------
 FROM registry.access.redhat.com/ubi9-minimal:9.2 as release-ubi
 
-ARG BIN_NAME
+ARG BIN_NAME=consul-dataplane
 ENV BIN_NAME=$BIN_NAME
 ARG PRODUCT_VERSION
 ARG PRODUCT_REVISION
@@ -126,10 +129,10 @@ RUN groupadd --gid 1000 $PRODUCT_NAME && \
     adduser --uid 100 --system -g $PRODUCT_NAME $PRODUCT_NAME && \
     usermod -a -G root $PRODUCT_NAME
 
-COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
-COPY --from=go-discover /go/bin/discover /usr/local/bin/
-COPY --from=envoy-setcap /usr/local/bin/envoy /usr/local/bin/envoy
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
+COPY --from=go-discover /go/bin/discover /usr/local/bin/
+COPY --from=setcap /usr/local/bin/envoy /usr/local/bin/
+COPY --from=setcap /usr/local/bin/$BIN_NAME /usr/local/bin/
 COPY LICENSE /licenses/copyright.txt
 
 USER 100


### PR DESCRIPTION
### Describe the issue
Consul-dataplane is currently unable to bind to privileged ports (< 1024).

This is important for ingress-gateway use cases where customers have historically been able to bind to ports such as `443` and are encountering runtime failures when attempting to upgrade to Consul 1.15+ and the corresponding Helm chart versions. In these newer versions, consul-dataplane has taken the place of the `envoyproxy/envoy` containers that were used previously.

Example of failure:
```shell
[warning] envoy.config(13) delta config for type.googleapis.com/envoy.config.listener.v3.Listener rejected: Error adding/updating listener(s) http:0.0.0.0:443: cannot bind '0.0.0.0:443': Permission denied
```

### Describe the fix
It appears that Envoy containers, which consul-dataplane has replaced for ingress-gateway use cases, run as root and then use `su-exec` to run as a different user. I'm thinking that we can set the `NET_BIND_SERVICE` capability directly on the Envoy and dataplane binaries and avoid starting up as `root`, but I'm depending on my own testing and reviewers here to validate this.
- The consul-dataplane container still needs to function correctly when deployed into OpenShift
- The consul-dataplane container still needs to function correctly with https://github.com/hashicorp/consul-k8s/pull/2755

This PR adds a new stage to set the `net_bind_service` capability on the Envoy and dataplane binaries that are copied into the release image. The final images then copy their Envoy and dataplane binaries from this new stage instead of their previous source.

### How to test
- Create an ingress-gateway that binds to a privileged port, such as `443` (see example values below)
  - Before this change, the consul-dataplane container will appear healthy but spew logs containing the error below
  - After this change, the consul-dataplane container will appear healthy, and the logs will indicate successful xDS config
- Do the same testing on OpenShift to verify no negative impact

<details>
<summary>Example `values.yaml`</summary>

```yaml
global:
  name: consul
  logLevel: debug

connectInject:
  replicas: 1
  enabled: true

server:
  replicas: 3

ingressGateways:
  enabled: true
  gateways:
    - name: my-ingress
      service:
        type: LoadBalancer
        ports:
          - port: 443
```

</details>
