### PR TITLE
Make consul dataplane handle bootstrap param response for V2 resources

### DIFF
--- a/.changelog/242.txt
+++ b/.changelog/242.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Make consul dataplane handle bootstrap param response for Catalog and Mesh V2 resources
+```

--- a/.changelog/242.txt
+++ b/.changelog/242.txt
@@ -1,3 +1,3 @@
-```release-note:security
+```release-note:feature
 Make consul dataplane handle bootstrap param response for Catalog and Mesh V2 resources
 ```

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+issues:
+  exclude-rules:
+    # Allow usage of deprecated values.
+    - linters: [ staticcheck ]
+      text: 'SA1019:'
+      path: "(pkg/consuldp/bootstrap.go)"

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"dario.cat/mergo"
+
 	"github.com/hashicorp/consul-dataplane/pkg/consuldp"
 )
 
@@ -77,13 +78,13 @@ type ServiceFlags struct {
 	Partition     *string `json:"partition,omitempty"`
 }
 
-func (sf ServiceFlags) IsEmpty() bool {
-	return sf.NodeName == nil &&
-		sf.NodeID == nil &&
-		sf.ServiceID == nil &&
-		sf.ServiceIDPath == nil &&
-		sf.Namespace == nil &&
-		sf.Partition == nil
+func (pf ProxyFlags) IsEmpty() bool {
+	return pf.NodeName == nil &&
+		pf.NodeID == nil &&
+		pf.ID == nil &&
+		pf.IDPath == nil &&
+		pf.Namespace == nil &&
+		pf.Partition == nil
 }
 
 type ProxyFlags struct {
@@ -268,21 +269,21 @@ func buildDefaultConsulDPFlags() (DataplaneConfigFlags, error) {
 func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*consuldp.Config, error) {
 	// Handle deprecated service flags.
 	var proxyCfg consuldp.ProxyConfig
-	if !cfg.Service.IsEmpty() {
-		proxyCfg = consuldp.ProxyConfig{
-			NodeName:  stringVal(cfg.Service.NodeName),
-			NodeID:    stringVal(cfg.Service.NodeID),
-			ProxyID:   stringVal(cfg.Service.ServiceID),
-			Namespace: stringVal(cfg.Service.Namespace),
-			Partition: stringVal(cfg.Service.Partition),
-		}
-	} else {
+	if !cfg.Proxy.IsEmpty() {
 		proxyCfg = consuldp.ProxyConfig{
 			NodeName:  stringVal(cfg.Proxy.NodeName),
 			NodeID:    stringVal(cfg.Proxy.NodeID),
 			ProxyID:   stringVal(cfg.Proxy.ID),
 			Namespace: stringVal(cfg.Proxy.Namespace),
 			Partition: stringVal(cfg.Proxy.Partition),
+		}
+	} else {
+		proxyCfg = consuldp.ProxyConfig{
+			NodeName:  stringVal(cfg.Service.NodeName),
+			NodeID:    stringVal(cfg.Service.NodeID),
+			ProxyID:   stringVal(cfg.Service.ServiceID),
+			Namespace: stringVal(cfg.Service.Namespace),
+			Partition: stringVal(cfg.Service.Partition),
 		}
 	}
 

--- a/cmd/consul-dataplane/config_test.go
+++ b/cmd/consul-dataplane/config_test.go
@@ -28,7 +28,7 @@ func TestConfigGeneration(t *testing.T) {
 		{
 			desc: "able to generate config properly when the config file input is empty",
 			flagOpts: func() (*FlagOpts, error) {
-				return generateFlagOpts()
+				return generateFlagOptsWithServiceFlags()
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
@@ -55,11 +55,11 @@ func TestConfigGeneration(t *testing.T) {
 							InsecureSkipVerify: true,
 						},
 					},
-					Service: &consuldp.ServiceConfig{
+					Proxy: &consuldp.ProxyConfig{
 						NodeName:  "test-node-dc1",
 						NodeID:    "dc1.node.id",
 						Namespace: "default",
-						ServiceID: "node1.service1",
+						ProxyID:   "node1.service1",
 						Partition: "default",
 					},
 					Logging: &consuldp.LoggingConfig{
@@ -104,9 +104,86 @@ func TestConfigGeneration(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			desc: "able to override all the config fields with CLI flags",
+			desc: "able to generate config properly with proxy flags when the config file input is empty",
 			flagOpts: func() (*FlagOpts, error) {
-				opts, err := generateFlagOpts()
+				return generateFlagOptsWithProxyFlags()
+			},
+			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
+				return &consuldp.Config{
+					Consul: &consuldp.ConsulConfig{
+						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
+						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
+						ServerWatchDisabled: true,
+						Credentials: &consuldp.CredentialsConfig{
+							Type: "static",
+							Static: consuldp.StaticCredentialsConfig{
+								Token: "test-token-123",
+							},
+							Login: consuldp.LoginCredentialsConfig{
+								AuthMethod:  "test-iam-auth",
+								BearerToken: "bearer-login",
+							},
+						},
+						TLS: &consuldp.TLSConfig{
+							Disabled:           false,
+							CACertsPath:        "/consul/",
+							CertFile:           "ca-cert.pem",
+							KeyFile:            "key.pem",
+							ServerName:         "tls-server-name",
+							InsecureSkipVerify: true,
+						},
+					},
+					Proxy: &consuldp.ProxyConfig{
+						NodeName:  "test-node-dc1",
+						NodeID:    "dc1.node.id",
+						Namespace: "default",
+						ProxyID:   "node1.service1",
+						Partition: "default",
+					},
+					Logging: &consuldp.LoggingConfig{
+						Name:     DefaultLogName,
+						LogJSON:  true,
+						LogLevel: "WARN",
+					},
+					DNSServer: &consuldp.DNSServerConfig{
+						BindAddr: "127.0.0.1",
+						Port:     8604,
+					},
+					XDSServer: &consuldp.XDSServer{
+						BindAddress: "127.0.1.0",
+						BindPort:    0,
+					},
+					Envoy: &consuldp.EnvoyConfig{
+						AdminBindAddress:              "127.0.1.0",
+						AdminBindPort:                 18000,
+						ReadyBindAddress:              "127.0.1.0",
+						ReadyBindPort:                 18003,
+						EnvoyConcurrency:              4,
+						EnvoyDrainStrategy:            "test-strategy",
+						ShutdownDrainListenersEnabled: true,
+						GracefulShutdownPath:          "/graceful_shutdown",
+						EnvoyDrainTimeSeconds:         30,
+						GracefulPort:                  20300,
+					},
+					Telemetry: &consuldp.TelemetryConfig{
+						UseCentralConfig: true,
+						Prometheus: consuldp.PrometheusTelemetryConfig{
+							RetentionTime: 10 * time.Second,
+							ScrapePath:    "/metrics",
+							MergePort:     12000,
+							CACertsPath:   "/consul/",
+							CertFile:      "prom-ca-cert.pem",
+							KeyFile:       "prom-key.pem",
+						},
+					},
+				}
+			},
+			wantErr: false,
+		},
+		{
+			desc: "able to override all the config fields with CLI flags when using service flags",
+			flagOpts: func() (*FlagOpts, error) {
+				opts, err := generateFlagOptsWithServiceFlags()
 				if err != nil {
 					return nil, err
 				}
@@ -158,11 +235,114 @@ func TestConfigGeneration(t *testing.T) {
 							InsecureSkipVerify: true,
 						},
 					},
-					Service: &consuldp.ServiceConfig{
+					Proxy: &consuldp.ProxyConfig{
 						NodeName:  "test-node-dc1",
 						NodeID:    "dc1.node.id",
 						Namespace: "default",
-						ServiceID: "node1.service1",
+						ProxyID:   "node1.service1",
+						Partition: "default",
+					},
+					Logging: &consuldp.LoggingConfig{
+						Name:     DefaultLogName,
+						LogJSON:  false,
+						LogLevel: "WARN",
+					},
+					DNSServer: &consuldp.DNSServerConfig{
+						BindAddr: "127.0.0.2",
+						Port:     8604,
+					},
+					XDSServer: &consuldp.XDSServer{
+						BindAddress: "127.0.1.0",
+						BindPort:    6060,
+					},
+					Envoy: &consuldp.EnvoyConfig{
+						AdminBindAddress:              "127.0.1.0",
+						AdminBindPort:                 18000,
+						ReadyBindAddress:              "127.0.1.0",
+						ReadyBindPort:                 18003,
+						EnvoyConcurrency:              4,
+						EnvoyDrainStrategy:            "test-strategy",
+						ShutdownDrainListenersEnabled: true,
+						GracefulShutdownPath:          "/graceful_shutdown",
+						EnvoyDrainTimeSeconds:         30,
+						GracefulPort:                  20300,
+						DumpEnvoyConfigOnExitEnabled:  true,
+					},
+					Telemetry: &consuldp.TelemetryConfig{
+						UseCentralConfig: true,
+						Prometheus: consuldp.PrometheusTelemetryConfig{
+							RetentionTime: 10 * time.Second,
+							ScrapePath:    "/metrics",
+							MergePort:     12000,
+							CACertsPath:   "/consul/",
+							CertFile:      "prom-ca-cert.pem",
+							KeyFile:       "prom-key.pem",
+						},
+					},
+				}
+			},
+			wantErr: false,
+		},
+		{
+			desc: "able to override all the config fields with CLI flags when using proxy flags",
+			flagOpts: func() (*FlagOpts, error) {
+				opts, err := generateFlagOptsWithProxyFlags()
+				if err != nil {
+					return nil, err
+				}
+				opts.dataplaneConfig.Consul.Credentials.Login.BearerTokenPath = strReference("/consul/bearertokenpath/")
+				opts.dataplaneConfig.Consul.Credentials.Login.Datacenter = strReference("dc100")
+				opts.dataplaneConfig.Consul.Credentials.Login.Meta = map[string]string{
+					"key-1": "value-1",
+					"key-2": "value-2",
+				}
+				opts.dataplaneConfig.Consul.Credentials.Login.Namespace = strReference("default")
+				opts.dataplaneConfig.Consul.Credentials.Login.Partition = strReference("default")
+
+				opts.dataplaneConfig.Logging.LogJSON = boolReference(false)
+				opts.dataplaneConfig.DNSServer.BindAddr = strReference("127.0.0.2")
+				opts.dataplaneConfig.XDSServer.BindPort = intReference(6060)
+				opts.dataplaneConfig.Envoy.DumpEnvoyConfigOnExitEnabled = boolReference(true)
+				return opts, nil
+			},
+			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
+				return &consuldp.Config{
+					Consul: &consuldp.ConsulConfig{
+						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
+						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
+						ServerWatchDisabled: true,
+						Credentials: &consuldp.CredentialsConfig{
+							Type: "static",
+							Static: consuldp.StaticCredentialsConfig{
+								Token: "test-token-123",
+							},
+							Login: consuldp.LoginCredentialsConfig{
+								Meta: map[string]string{
+									"key-1": "value-1",
+									"key-2": "value-2",
+								},
+								AuthMethod:      "test-iam-auth",
+								BearerToken:     "bearer-login",
+								BearerTokenPath: "/consul/bearertokenpath/",
+								Namespace:       "default",
+								Partition:       "default",
+								Datacenter:      "dc100",
+							},
+						},
+						TLS: &consuldp.TLSConfig{
+							Disabled:           false,
+							CACertsPath:        "/consul/",
+							CertFile:           "ca-cert.pem",
+							KeyFile:            "key.pem",
+							ServerName:         "tls-server-name",
+							InsecureSkipVerify: true,
+						},
+					},
+					Proxy: &consuldp.ProxyConfig{
+						NodeName:  "test-node-dc1",
+						NodeID:    "dc1.node.id",
+						Namespace: "default",
+						ProxyID:   "node1.service1",
 						Partition: "default",
 					},
 					Logging: &consuldp.LoggingConfig{
@@ -221,9 +401,9 @@ func TestConfigGeneration(t *testing.T) {
 					  "grpcPort": 8502,
 					  "serverWatchDisabled": false
 					},
-					"service": {
+					"proxy": {
 					  "nodeName": "test-node-1",
-					  "serviceId": "frontend-service-sidecar-proxy",
+					  "id": "frontend-service-sidecar-proxy",
 					  "namespace": "default",
 					  "partition": "default"
 					},
@@ -259,10 +439,10 @@ func TestConfigGeneration(t *testing.T) {
 						},
 						TLS: &consuldp.TLSConfig{},
 					},
-					Service: &consuldp.ServiceConfig{
+					Proxy: &consuldp.ProxyConfig{
 						NodeName:  "test-node-1",
 						Namespace: "default",
-						ServiceID: "frontend-service-sidecar-proxy",
+						ProxyID:   "frontend-service-sidecar-proxy",
 						Partition: "default",
 					},
 					Logging: &consuldp.LoggingConfig{
@@ -306,7 +486,7 @@ func TestConfigGeneration(t *testing.T) {
 		{
 			desc: "test whether CLI flag values override the file values",
 			flagOpts: func() (*FlagOpts, error) {
-				opts, err := generateFlagOpts()
+				opts, err := generateFlagOptsWithServiceFlags()
 				if err != nil {
 					return nil, err
 				}
@@ -381,11 +561,11 @@ func TestConfigGeneration(t *testing.T) {
 							InsecureSkipVerify: true,
 						},
 					},
-					Service: &consuldp.ServiceConfig{
+					Proxy: &consuldp.ProxyConfig{
 						NodeName:  "test-node-dc1",
 						NodeID:    "dc1.node.id",
 						Namespace: "default",
-						ServiceID: "node1.service1",
+						ProxyID:   "node1.service1",
 						Partition: "default",
 					},
 					Logging: &consuldp.LoggingConfig{
@@ -453,7 +633,7 @@ func TestConfigGeneration(t *testing.T) {
 	}
 }
 
-func generateFlagOpts() (*FlagOpts, error) {
+func generateFlagOptsWithServiceFlags() (*FlagOpts, error) {
 	data := `
 	{
 		"consul": {
@@ -484,6 +664,81 @@ func generateFlagOpts() (*FlagOpts, error) {
 			"nodeID": "dc1.node.id",
 			"namespace": "default",
 			"serviceID": "node1.service1",
+			"partition": "default"
+		},
+		"logging": {
+			"logJSON": true,
+			"logLevel": "warn"
+		},
+		"telemetry": {
+			"useCentralConfig": true,
+			"prometheus": {
+				"retentionTime": "10s",
+				"scrapePath": "/metrics",
+				"mergePort": 12000,
+				"caCertsPath": "/consul/",
+				"certFile": "prom-ca-cert.pem",
+				"keyFile": "prom-key.pem"
+			}
+		},
+		"envoy": {
+			"adminBindAddress": "127.0.1.0",
+			"adminBindPort": 18000,
+			"readyBindAddress": "127.0.1.0",
+			"readyBindPort": 18003,
+			"concurrency": 4,
+			"drainStrategy": "test-strategy",
+			"shutdownDrainListenersEnabled": true
+		},
+		"xdsServer": {
+			"bindAddress": "127.0.1.0"
+		},
+		"dnsServer": {
+			"bindPort": 8604
+		}
+	}`
+
+	var configFlags *DataplaneConfigFlags
+	err := json.Unmarshal([]byte(data), &configFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FlagOpts{
+		dataplaneConfig: *configFlags,
+	}, nil
+}
+func generateFlagOptsWithProxyFlags() (*FlagOpts, error) {
+	data := `
+	{
+		"consul": {
+			"addresses": "` + fmt.Sprintf("consul.address.server_%d", rand.Int()) + `",
+			"grpcPort": ` + fmt.Sprintf("%d", rand.Int()) + `,
+			"serverWatchDisabled": true,
+			"tls": {
+				"disabled": false,
+				"caCertsPath": "/consul/",
+				"certFile": "ca-cert.pem",
+				"keyFile": "key.pem",
+				"serverName": "tls-server-name",
+				"insecureSkipVerify": true
+			},
+			"credentials": {
+				"type": "static",
+				"static": {
+					"token": "test-token-123"
+				},
+				"login": {
+					"authMethod": "test-iam-auth",
+					"bearerToken": "bearer-login"
+				}
+			}
+		},
+		"proxy": {
+			"nodeName": "test-node-dc1",
+			"nodeID": "dc1.node.id",
+			"namespace": "default",
+			"id": "node1.service1",
 			"partition": "default"
 		},
 		"logging": {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
 	github.com/hashicorp/consul-server-connection-manager v0.1.3
-	github.com/hashicorp/consul/proto-public v0.4.0
+	github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-rootcerts v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
 	github.com/hashicorp/consul-server-connection-manager v0.1.3
-	github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6
+	github.com/hashicorp/consul/proto-public v0.1.2-0.20230901221336-4ef6db6b7c6b
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-rootcerts v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/adamthesax/grpc-proxy v0.0.0-20220525203857-13e92d14f87a
 	github.com/armon/go-metrics v0.4.1
 	github.com/hashicorp/consul-server-connection-manager v0.1.3
-	github.com/hashicorp/consul/proto-public v0.1.2-0.20230901221336-4ef6db6b7c6b
+	github.com/hashicorp/consul/proto-public v0.1.2-0.20230905183425-7549c48596bd
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-rootcerts v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/hashicorp/consul-server-connection-manager v0.1.3 h1:fxsZ15XBNNWhV26y
 github.com/hashicorp/consul-server-connection-manager v0.1.3/go.mod h1:Md2IGKaFJ4ek9GUA0pW1S2R60wpquMOUs27GiD9kZd0=
 github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6 h1:pKV0tV5j9637S7SCMicxNVqNY2QUxT50dMn/hBsG7hE=
 github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6/go.mod h1:ENwzmloQTUPAYPu7nC1mli3VY0Ny9QNi/FSzJ+KlZD0=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230901221336-4ef6db6b7c6b h1:YZCrpPpUEBzYQqznzArMo6QteWWJmvCoHEDhniQB3XE=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230901221336-4ef6db6b7c6b/go.mod h1:ENwzmloQTUPAYPu7nC1mli3VY0Ny9QNi/FSzJ+KlZD0=
 github.com/hashicorp/consul/sdk v0.13.0 h1:lce3nFlpv8humJL8rNrrGHYSKc3q+Kxfeg3Ii1m6ZWU=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.sum
+++ b/go.sum
@@ -147,10 +147,10 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/consul-server-connection-manager v0.1.3 h1:fxsZ15XBNNWhV26yBVdCcnxHwSRgf9wqHGS2ZVCQIhc=
 github.com/hashicorp/consul-server-connection-manager v0.1.3/go.mod h1:Md2IGKaFJ4ek9GUA0pW1S2R60wpquMOUs27GiD9kZd0=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6 h1:pKV0tV5j9637S7SCMicxNVqNY2QUxT50dMn/hBsG7hE=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6/go.mod h1:ENwzmloQTUPAYPu7nC1mli3VY0Ny9QNi/FSzJ+KlZD0=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230901221336-4ef6db6b7c6b h1:YZCrpPpUEBzYQqznzArMo6QteWWJmvCoHEDhniQB3XE=
-github.com/hashicorp/consul/proto-public v0.1.2-0.20230901221336-4ef6db6b7c6b/go.mod h1:ENwzmloQTUPAYPu7nC1mli3VY0Ny9QNi/FSzJ+KlZD0=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230905183425-7549c48596bd h1:FtFuI6BlSIgsjX2F1XvwhL+u6KaI60kVyh2Az07cTnE=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230905183425-7549c48596bd/go.mod h1:ENwzmloQTUPAYPu7nC1mli3VY0Ny9QNi/FSzJ+KlZD0=
+github.com/hashicorp/consul/proto-public v0.4.1 h1:k1RWFQo3uvtaLyC8ZEdP2jJOCiNp/7Tp8zz9MsjAxc8=
+github.com/hashicorp/consul/proto-public v0.4.1/go.mod h1:ENwzmloQTUPAYPu7nC1mli3VY0Ny9QNi/FSzJ+KlZD0=
 github.com/hashicorp/consul/sdk v0.13.0 h1:lce3nFlpv8humJL8rNrrGHYSKc3q+Kxfeg3Ii1m6ZWU=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/consul-server-connection-manager v0.1.3 h1:fxsZ15XBNNWhV26yBVdCcnxHwSRgf9wqHGS2ZVCQIhc=
 github.com/hashicorp/consul-server-connection-manager v0.1.3/go.mod h1:Md2IGKaFJ4ek9GUA0pW1S2R60wpquMOUs27GiD9kZd0=
-github.com/hashicorp/consul/proto-public v0.4.0 h1:amEli9TgZBatDzvqW+k9E2HQEfOrIkIAlAreeP7vIlA=
-github.com/hashicorp/consul/proto-public v0.4.0/go.mod h1:yOSsnXuMvtPPs9X9U44fb1xbUyOxY9jxuYs4R+ilxYU=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6 h1:pKV0tV5j9637S7SCMicxNVqNY2QUxT50dMn/hBsG7hE=
+github.com/hashicorp/consul/proto-public v0.1.2-0.20230817221841-aac2dac759c6/go.mod h1:ENwzmloQTUPAYPu7nC1mli3VY0Ny9QNi/FSzJ+KlZD0=
 github.com/hashicorp/consul/sdk v0.13.0 h1:lce3nFlpv8humJL8rNrrGHYSKc3q+Kxfeg3Ii1m6ZWU=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -11,10 +11,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v1alpha1"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/consul-dataplane/internal/bootstrap"
 )
 
 const (
@@ -77,9 +78,9 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 		PrometheusScrapePath:  prom.ScrapePath,
 	}
 
-	if rsp.ClusterName != "" {
-		args.ProxyCluster = rsp.ClusterName
-		args.ProxySourceService = rsp.ClusterName
+	if rsp.Identity != "" {
+		args.ProxyCluster = rsp.Identity
+		args.ProxySourceService = rsp.Identity
 	}
 
 	if cdp.xdsServer.listenerNetwork == "unix" {

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -68,8 +68,8 @@ func TestBootstrapConfig(t *testing.T) {
 				AccessLogs: []string{"{\"name\":\"Consul Listener Filter Log\",\"typedConfig\":{\"@type\":\"type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog\",\"logFormat\":{\"jsonFormat\":{\"custom_field\":\"%START_TIME%\"}}}}"},
 			},
 			&pbdataplane.GetEnvoyBootstrapParamsResponse{
-				ClusterName: "web",
-				NodeName:    nodeName,
+				Identity: "web",
+				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					DogstatsdUrl: "this-should-not-appear-in-generated-config",
 				},
@@ -99,8 +99,8 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 			},
 			&pbdataplane.GetEnvoyBootstrapParamsResponse{
-				ClusterName: "web",
-				NodeName:    nodeName,
+				Identity: "web",
+				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					DogstatsdUrl: "this-should-not-appear-in-generated-config",
 				},
@@ -129,8 +129,8 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 			},
 			&pbdataplane.GetEnvoyBootstrapParamsResponse{
-				ClusterName: "web",
-				NodeName:    nodeName,
+				Identity: "web",
+				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					DogstatsdUrl: "udp://127.0.0.1:9125",
 				},
@@ -161,9 +161,9 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 			},
 			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
-				ClusterName: "web",
-				Namespace:   "default",
-				NodeName:    nodeName,
+				Identity:  "web",
+				Namespace: "default",
+				NodeName:  nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					TelemetryCollectorBindSocketDir: "/tmp/consul/hcp-metrics",
 				},
@@ -196,8 +196,8 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 			},
 			&pbdataplane.GetEnvoyBootstrapParamsResponse{
-				ClusterName: "web",
-				NodeName:    nodeName,
+				Identity: "web",
+				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					PrometheusBindAddr: "0.0.0.0:20200",
 				},
@@ -225,8 +225,8 @@ func TestBootstrapConfig(t *testing.T) {
 				NodeName: nodeName,
 			},
 			&pbdataplane.GetEnvoyBootstrapParamsResponse{
-				ClusterName: "web",
-				NodeName:    nodeName,
+				Identity: "web",
+				NodeName: nodeName,
 			},
 		},
 		"unix-socket-xds-server": {
@@ -252,8 +252,8 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 			},
 			&pbdataplane.GetEnvoyBootstrapParamsResponse{
-				ClusterName: "web",
-				NodeName:    nodeName,
+				Identity: "web",
+				NodeName: nodeName,
 				BootstrapConfig: &pbmesh.BootstrapConfig{
 					DogstatsdUrl: "this-should-not-appear-in-generated-config",
 				},

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
+	pbmesh "github.com/hashicorp/consul/proto-public/pbmesh/v1alpha1"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -39,14 +40,15 @@ func TestBootstrapConfig(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		cfg *Config
-		rsp *pbdataplane.GetEnvoyBootstrapParamsResponse
+		cfg   *Config
+		rsp   *pbdataplane.GetEnvoyBootstrapParamsResponse
+		rspV2 *pbdataplane.GetEnvoyBootstrapParamsResponse
 	}{
 		"access-logs": {
 			&Config{
-				Service: &ServiceConfig{
-					ServiceID: "web-proxy",
-					NodeName:  nodeName,
+				Proxy: &ProxyConfig{
+					ProxyID:  "web-proxy",
+					NodeName: nodeName,
 				},
 				Envoy: &EnvoyConfig{
 					AdminBindAddress: "127.0.0.1",
@@ -65,12 +67,20 @@ func TestBootstrapConfig(t *testing.T) {
 				}),
 				AccessLogs: []string{"{\"name\":\"Consul Listener Filter Log\",\"typedConfig\":{\"@type\":\"type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog\",\"logFormat\":{\"jsonFormat\":{\"custom_field\":\"%START_TIME%\"}}}}"},
 			},
+			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+				ClusterName: "web",
+				NodeName:    nodeName,
+				BootstrapConfig: &pbmesh.BootstrapConfig{
+					DogstatsdUrl: "this-should-not-appear-in-generated-config",
+				},
+				AccessLogs: []string{"{\"name\":\"Consul Listener Filter Log\",\"typedConfig\":{\"@type\":\"type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog\",\"logFormat\":{\"jsonFormat\":{\"custom_field\":\"%START_TIME%\"}}}}"},
+			},
 		},
 		"basic": {
 			&Config{
-				Service: &ServiceConfig{
-					ServiceID: "web-proxy",
-					NodeName:  nodeName,
+				Proxy: &ProxyConfig{
+					ProxyID:  "web-proxy",
+					NodeName: nodeName,
 				},
 				Envoy: &EnvoyConfig{
 					AdminBindAddress: "127.0.0.1",
@@ -88,12 +98,19 @@ func TestBootstrapConfig(t *testing.T) {
 					"envoy_dogstatsd_url": "this-should-not-appear-in-generated-config",
 				}),
 			},
+			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+				ClusterName: "web",
+				NodeName:    nodeName,
+				BootstrapConfig: &pbmesh.BootstrapConfig{
+					DogstatsdUrl: "this-should-not-appear-in-generated-config",
+				},
+			},
 		},
 		"central-telemetry-config": {
 			&Config{
-				Service: &ServiceConfig{
-					ServiceID: "web-proxy",
-					NodeName:  nodeName,
+				Proxy: &ProxyConfig{
+					ProxyID:  "web-proxy",
+					NodeName: nodeName,
 				},
 				Envoy: &EnvoyConfig{
 					AdminBindAddress: "127.0.0.1",
@@ -111,11 +128,18 @@ func TestBootstrapConfig(t *testing.T) {
 					"envoy_dogstatsd_url": "udp://127.0.0.1:9125",
 				}),
 			},
+			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+				ClusterName: "web",
+				NodeName:    nodeName,
+				BootstrapConfig: &pbmesh.BootstrapConfig{
+					DogstatsdUrl: "udp://127.0.0.1:9125",
+				},
+			},
 		},
 		"hcp-metrics": {
 			cfg: &Config{
-				Service: &ServiceConfig{
-					ServiceID: "web-proxy",
+				Proxy: &ProxyConfig{
+					ProxyID:   "web-proxy",
 					NodeName:  nodeName,
 					Namespace: "default",
 				},
@@ -136,12 +160,20 @@ func TestBootstrapConfig(t *testing.T) {
 					"envoy_telemetry_collector_bind_socket_dir": "/tmp/consul/hcp-metrics",
 				}),
 			},
+			rspV2: &pbdataplane.GetEnvoyBootstrapParamsResponse{
+				ClusterName: "web",
+				Namespace:   "default",
+				NodeName:    nodeName,
+				BootstrapConfig: &pbmesh.BootstrapConfig{
+					TelemetryCollectorBindSocketDir: "/tmp/consul/hcp-metrics",
+				},
+			},
 		},
 		"custom-prometheus-scrape-path": {
 			&Config{
-				Service: &ServiceConfig{
-					ServiceID: "web-proxy",
-					NodeName:  nodeName,
+				Proxy: &ProxyConfig{
+					ProxyID:  "web-proxy",
+					NodeName: nodeName,
 				},
 				Envoy: &EnvoyConfig{
 					AdminBindAddress: "127.0.0.1",
@@ -163,12 +195,19 @@ func TestBootstrapConfig(t *testing.T) {
 					"envoy_prometheus_bind_addr": "0.0.0.0:20200",
 				}),
 			},
+			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+				ClusterName: "web",
+				NodeName:    nodeName,
+				BootstrapConfig: &pbmesh.BootstrapConfig{
+					PrometheusBindAddr: "0.0.0.0:20200",
+				},
+			},
 		},
 		"ready-listener": {
 			&Config{
-				Service: &ServiceConfig{
-					ServiceID: "web-proxy",
-					NodeName:  nodeName,
+				Proxy: &ProxyConfig{
+					ProxyID:  "web-proxy",
+					NodeName: nodeName,
 				},
 				Envoy: &EnvoyConfig{
 					AdminBindAddress: "127.0.0.1",
@@ -185,12 +224,16 @@ func TestBootstrapConfig(t *testing.T) {
 				Service:  "web",
 				NodeName: nodeName,
 			},
+			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+				ClusterName: "web",
+				NodeName:    nodeName,
+			},
 		},
 		"unix-socket-xds-server": {
 			&Config{
-				Service: &ServiceConfig{
-					ServiceID: "web-proxy",
-					NodeName:  nodeName,
+				Proxy: &ProxyConfig{
+					ProxyID:  "web-proxy",
+					NodeName: nodeName,
 				},
 				Envoy: &EnvoyConfig{
 					AdminBindAddress: "127.0.0.1",
@@ -208,21 +251,61 @@ func TestBootstrapConfig(t *testing.T) {
 					"envoy_dogstatsd_url": "this-should-not-appear-in-generated-config",
 				}),
 			},
+			&pbdataplane.GetEnvoyBootstrapParamsResponse{
+				ClusterName: "web",
+				NodeName:    nodeName,
+				BootstrapConfig: &pbmesh.BootstrapConfig{
+					DogstatsdUrl: "this-should-not-appear-in-generated-config",
+				},
+			},
 		},
 	}
 	for desc, tc := range testCases {
-		t.Run(desc, func(t *testing.T) {
+		t.Run(desc+"-v1", func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
 
 			client := NewMockDataplaneServiceClient(t)
 			client.EXPECT().
 				GetEnvoyBootstrapParams(mock.Anything, &pbdataplane.GetEnvoyBootstrapParamsRequest{
-					NodeSpec:  &pbdataplane.GetEnvoyBootstrapParamsRequest_NodeName{NodeName: tc.cfg.Service.NodeName},
-					ServiceId: tc.cfg.Service.ServiceID,
-					Namespace: tc.cfg.Service.Namespace,
+					NodeSpec:  &pbdataplane.GetEnvoyBootstrapParamsRequest_NodeName{NodeName: tc.cfg.Proxy.NodeName},
+					ServiceId: tc.cfg.Proxy.ProxyID,
+					ProxyId:   tc.cfg.Proxy.ProxyID,
+					Namespace: tc.cfg.Proxy.Namespace,
 				}).Call.
 				Return(tc.rsp, nil)
+
+			dp := &ConsulDataplane{
+				cfg:             tc.cfg,
+				dpServiceClient: client,
+			}
+
+			if strings.HasPrefix(tc.cfg.XDSServer.BindAddress, "unix://") {
+				dp.xdsServer = &xdsServer{listenerAddress: socketPath, listenerNetwork: "unix"}
+			} else {
+				dp.xdsServer = &xdsServer{listenerAddress: fmt.Sprintf("127.0.0.1:%d", xdsBindPort)}
+			}
+
+			_, bsCfg, err := dp.bootstrapConfig(ctx)
+			require.NoError(t, err)
+
+			golden(t, bsCfg)
+			validateBootstrapConfig(t, bsCfg)
+		})
+
+		t.Run(desc+"-v2", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			client := NewMockDataplaneServiceClient(t)
+			client.EXPECT().
+				GetEnvoyBootstrapParams(mock.Anything, &pbdataplane.GetEnvoyBootstrapParamsRequest{
+					NodeSpec:  &pbdataplane.GetEnvoyBootstrapParamsRequest_NodeName{NodeName: tc.cfg.Proxy.NodeName},
+					ServiceId: tc.cfg.Proxy.ProxyID,
+					ProxyId:   tc.cfg.Proxy.ProxyID,
+					Namespace: tc.cfg.Proxy.Namespace,
+				}).Call.
+				Return(tc.rspV2, nil)
 
 			dp := &ConsulDataplane{
 				cfg:             tc.cfg,
@@ -247,7 +330,10 @@ func TestBootstrapConfig(t *testing.T) {
 func golden(t *testing.T, actual []byte) {
 	t.Helper()
 
-	goldenPath := filepath.Join("testdata", t.Name()+".golden")
+	fileName := strings.TrimSuffix(t.Name(), "-v1")
+	fileName = strings.TrimSuffix(fileName, "-v2")
+
+	goldenPath := filepath.Join("testdata", fileName+".golden")
 
 	if *update {
 		require.NoError(t, os.WriteFile(goldenPath, actual, 0644))

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -209,21 +209,21 @@ type LoggingConfig struct {
 	LogJSON bool
 }
 
-// ServiceConfig contains details of the proxy service instance.
-type ServiceConfig struct {
+// ProxyConfig contains details of the proxy service instance.
+type ProxyConfig struct {
 	// NodeName is the name of the node to which the proxy service instance is
-	// registered.
+	// registered. Ignored in Consul Catalog V2.
 	NodeName string
 	// NodeName is the ID of the node to which the proxy service instance is
-	// registered.
+	// registered. Ignored in Consul Catalog V2.
 	NodeID string
-	// ServiceID is the ID of the proxy service instance.
-	ServiceID string
+	// ProxyID is the ID of the proxy service instance or workload.
+	ProxyID string
 	// Namespace is the Consul Enterprise namespace in which the proxy service
-	// instance is registered.
+	// instance or workload is registered.
 	Namespace string
 	// Partition is the Consul Enterprise partition in which the proxy service
-	// instance is registered.
+	// instance or workload is registered.
 	Partition string
 }
 
@@ -318,7 +318,7 @@ type XDSServer struct {
 type Config struct {
 	DNSServer *DNSServerConfig
 	Consul    *ConsulConfig
-	Service   *ServiceConfig
+	Proxy     *ProxyConfig
 	Logging   *LoggingConfig
 	Telemetry *TelemetryConfig
 	Envoy     *EnvoyConfig

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -77,11 +77,11 @@ func validateConfig(cfg *Config) error {
 		return errors.New("consul addresses not specified")
 	case cfg.Consul.GRPCPort == 0:
 		return errors.New("consul server gRPC port not specified")
-	case cfg.Service == nil:
+	case cfg.Proxy == nil:
 		return errors.New("service details not specified")
-	case cfg.Service.NodeID == "" && cfg.Service.NodeName == "":
+	case cfg.Proxy.NodeID == "" && cfg.Proxy.NodeName == "":
 		return errors.New("node name or ID not specified")
-	case cfg.Service.ServiceID == "":
+	case cfg.Proxy.ProxyID == "":
 		return errors.New("proxy service ID not specified")
 	case cfg.Envoy == nil:
 		return errors.New("envoy settings not specified")

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -78,11 +78,9 @@ func validateConfig(cfg *Config) error {
 	case cfg.Consul.GRPCPort == 0:
 		return errors.New("consul server gRPC port not specified")
 	case cfg.Proxy == nil:
-		return errors.New("service details not specified")
-	case cfg.Proxy.NodeID == "" && cfg.Proxy.NodeName == "":
-		return errors.New("node name or ID not specified")
+		return errors.New("proxy details not specified")
 	case cfg.Proxy.ProxyID == "":
-		return errors.New("proxy service ID not specified")
+		return errors.New("proxy ID not specified")
 	case cfg.Envoy == nil:
 		return errors.New("envoy settings not specified")
 	case cfg.Envoy.AdminBindAddress == "":

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -22,9 +22,9 @@ func validConfig() *Config {
 				},
 			},
 		},
-		Service: &ServiceConfig{
-			NodeName:  "agentless-node",
-			ServiceID: "web-proxy",
+		Proxy: &ProxyConfig{
+			NodeName: "agentless-node",
+			ProxyID:  "web-proxy",
 		},
 		Logging: &LoggingConfig{
 			LogLevel: "INFO",
@@ -89,28 +89,28 @@ func TestNewConsulDPError(t *testing.T) {
 		},
 		{
 			name:      "missing service config",
-			modFn:     func(c *Config) { c.Service = nil },
+			modFn:     func(c *Config) { c.Proxy = nil },
 			expectErr: "service details not specified",
 		},
 		{
 			name: "missing node details",
 			modFn: func(c *Config) {
-				c.Service.NodeName = ""
-				c.Service.NodeID = ""
+				c.Proxy.NodeName = ""
+				c.Proxy.NodeID = ""
 			},
 			expectErr: "node name or ID not specified",
 		},
 		{
 			name: "missing node details",
 			modFn: func(c *Config) {
-				c.Service.NodeName = ""
-				c.Service.NodeID = ""
+				c.Proxy.NodeName = ""
+				c.Proxy.NodeID = ""
 			},
 			expectErr: "node name or ID not specified",
 		},
 		{
 			name:      "missing service id",
-			modFn:     func(c *Config) { c.Service.ServiceID = "" },
+			modFn:     func(c *Config) { c.Proxy.ProxyID = "" },
 			expectErr: "proxy service ID not specified",
 		},
 		{

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -88,30 +88,14 @@ func TestNewConsulDPError(t *testing.T) {
 			expectErr: "consul server gRPC port not specified",
 		},
 		{
-			name:      "missing service config",
+			name:      "missing proxy config",
 			modFn:     func(c *Config) { c.Proxy = nil },
-			expectErr: "service details not specified",
+			expectErr: "proxy details not specified",
 		},
 		{
-			name: "missing node details",
-			modFn: func(c *Config) {
-				c.Proxy.NodeName = ""
-				c.Proxy.NodeID = ""
-			},
-			expectErr: "node name or ID not specified",
-		},
-		{
-			name: "missing node details",
-			modFn: func(c *Config) {
-				c.Proxy.NodeName = ""
-				c.Proxy.NodeID = ""
-			},
-			expectErr: "node name or ID not specified",
-		},
-		{
-			name:      "missing service id",
+			name:      "missing proxy id",
 			modFn:     func(c *Config) { c.Proxy.ProxyID = "" },
-			expectErr: "proxy service ID not specified",
+			expectErr: "proxy ID not specified",
 		},
 		{
 			name:      "missing envoy config",

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -170,7 +170,7 @@ func TestMetricsServerEnabled(t *testing.T) {
 			require.IsType(t, &http.Client{}, m.client)
 			require.Greater(t, m.client.(*http.Client).Timeout, time.Duration(0))
 
-			// Mock get requests to Envoy and Service instance metrics
+			// Mock get requests to Envoy and Proxy instance metrics
 			// so that they return a fake metric string.
 			m.client = &mockClient{}
 


### PR DESCRIPTION
* Handle bootstrap_config param
* Use new request and response params
* Make flags/config more generic so that they can accomodate services or workloads and deprecate old flags/config.
Part of NET-5221