### PR TITLE
[NET-4904] security: Update Envoy FIPS to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@
 # prebuilt binaries in any other form.
 FROM envoyproxy/envoy-distroless:v1.26.4 as envoy-binary
 
-# TODO once hashicorp/envoy-fips:v1.26.4 is published this should be updated as well
-FROM hashicorp/envoy-fips:v1.26.2 as envoy-fips-binary
+FROM hashicorp/envoy-fips:v1.26.4 as envoy-fips-binary
 
 # go-discover builds the discover binary (which we don't currently publish
 # either).


### PR DESCRIPTION
Update `hashicorp/envoy-fips` image to match the standard version that was already updated.

Follow-up to https://github.com/hashicorp/consul-dataplane/pull/235.