### PR TITLE
Revert "switch to hashicorp envoy image (#263)"

### DIFF
--- a/.changelog/263.txt
+++ b/.changelog/263.txt
@@ -1,3 +1,0 @@
-```release-note:update
-Have consul dataplane use HashiCorp-published Envoy
-```

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # envoy-binary pulls in the latest Envoy binary, as Envoy don't publish
 # prebuilt binaries in any other form.
-FROM hashicorp/envoy:1.26.4 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.26.4 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary


### PR DESCRIPTION
This reverts commit 5eefda7e7ea5f44db41e72bb5a4c1474cec263a5 since hashicorp/envoy is not multi arch and is breaking consul-dataplane in use in acceptance tests.