### PR TITLE
Update to use CRT prepare workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -32,133 +32,17 @@ event "build" {
   }
 }
 
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-binaries" {
-  depends = ["upload-dev"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-containers" {
-  depends = ["security-scan-binaries"]
-  action "security-scan-containers" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-containers"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-amd64" {
-  depends = ["security-scan-containers"]
-  action "notarize-darwin-amd64" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "notarize-darwin-amd64"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "notarize-darwin-arm64" {
-  depends = ["notarize-darwin-amd64"]
-  action "notarize-darwin-arm64" {
+  action "prepare" {
     organization = "hashicorp"
     repository   = "crt-workflows-common"
-    workflow     = "notarize-darwin-arm64"
+    workflow     = "prepare"
+    depends      = ["build"]
   }
 
   notification {
     on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["notarize-darwin-arm64"]
-  action "sign" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign-linux-rpms" {
-  depends = ["sign"]
-  action "sign-linux-rpms" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign-linux-rpms"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign-linux-rpms"]
-  action "verify" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
-  }
-
-  notification {
-    on = "always"
-  }
-}
-
-event "promote-dev-docker" {
-  depends = ["verify"]
-  action "promote-dev-docker" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-dev-docker"
-    depends = ["verify"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "fossa-scan" {
-  depends = ["promote-dev-docker"]
-  action "fossa-scan" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "fossa-scan"
   }
 }
 


### PR DESCRIPTION
This update, moves consul-template to use the prepare workflow. This workflow encapsulates several previous workflows, running jobs in parallel to reduce the artifact processing time. See [here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2489712686/Dec+7th+2022+-+Introducing+the+new+Prepare+workflow) for more info .