### PR TITLE
manual backport of update backport assistant to use merge commits to 1.0.x

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -1,0 +1,31 @@
+# This action creates downstream PRs for PRs with backport labels defined.
+# See docs here: https://github.com/hashicorp/backport-assistant
+
+name: Backport Assistant Runner
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+    branches:
+      - main
+      - 'release/*.*.x'
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.3.5
+    steps:
+      - name: Run Backport Assistant for release branches
+        run: |
+          backport-assistant backport -merge-method=squash -gh-automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
+          BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
+          # This forces the backport assistant to backport the merged commit
+          # instead of each commit individually. The environment variable
+          # just needs to exist for this to happen.
+          BACKPORT_MERGE_COMMIT: true
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION


Setting this environment variable causes the backport assistant to use the merge commit instead of individual commits when backporting a PR. This should prevent the assistant from trying to backport 100s of commits. Nomad uses this flag and it has helped a lot.

From the docs:

> BACKPORT_MERGE_COMMIT: When nonempty, backport-assistant will try to backport the merge commit instead of the individual commits that make of the PR. This will only work if you exclusively use the squash-merge commit strategy for PRs that get backported.

