### PR TITLE
revert backport assistant change

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -24,8 +24,4 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
-          # This forces the backport assistant to backport the merged commit
-          # instead of each commit individually. The environment variable
-          # just needs to exist for this to happen.
-          BACKPORT_MERGE_COMMIT: true
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
This must have bugs. Not reverting because I want to keep the backport-assistance action update.