### PR TITLE
release/1.3.x - Update Envoy versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # envoy-binary pulls in the latest Envoy binary, as Envoy don't publish
 # prebuilt binaries in any other form.
-FROM envoyproxy/envoy-distroless:v1.26.4 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.27.2 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary


### PR DESCRIPTION
This PR updates Envoy to the latest patch release to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76).