### PR TITLE
Update FIPS Envoy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt install -y libcap2-bin
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/envoy
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/$BIN_NAME
 
-FROM hashicorp/envoy-fips:v1.26.4 as envoy-fips-binary
+FROM hashicorp/envoy-fips:1.27.2-fips1402 as envoy-fips-binary
 
 # Modify the envoy-fips binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-fips-binary


### PR DESCRIPTION
This PR updates FIPS Envoy to the latest patch release to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76).

Release branch PRs:
1.3.0: https://github.com/hashicorp/consul-dataplane/pull/318
1.3.x: https://github.com/hashicorp/consul-dataplane/pull/319
1.2.x: https://github.com/hashicorp/consul-dataplane/pull/320
