### PR TITLE
add 1.3.0 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,52 @@
+## 1.3.0 (November 6, 2023)
+
+SECURITY:
+
+* Update Envoy version to 1.27.2 to address [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76) [[GH-315](https://github.com/hashicorp/consul-dataplane/pull/315)]
+* Upgrade `google.golang.org/grpc` to 1.56.3.
+  This resolves vulnerability [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487). [[GH-323](https://github.com/hashicorp/consul-dataplane/pull/323)]
+* Upgrade to use Go 1.20.10 and `x/net` 0.17.0.
+  This resolves [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325)
+  / [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487). [[GH-299](https://github.com/hashicorp/consul-dataplane/pull/299)]
+
+## 1.3.0-rc1 (October 10, 2023)
+
+SECURITY:
+
+* Update to Go 1.20.7 and Envoy 1.26.4 within the Dockerfile. [[GH-235](https://github.com/hashicorp/consul-dataplane/pull/235)]
+* Upgrade to use Go 1.20.6 and `x/net/http` 0.12.0.
+  This resolves [CVE-2023-29406](https://github.com/advisories/GHSA-f8f7-69v5-w4vx)(`net/http`). [[GH-219](https://github.com/hashicorp/consul-dataplane/pull/219)]
+* Upgrade to use Go 1.20.7 and `x/net` 0.13.0.
+  This resolves [CVE-2023-29409](https://nvd.nist.gov/vuln/detail/CVE-2023-29409)(`crypto/tls`)
+  and [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978)(`net/html`). [[GH-227](https://github.com/hashicorp/consul-dataplane/pull/227)]
+* Upgrade to use Go 1.20.8. This resolves CVEs
+  [CVE-2023-39320](https://github.com/advisories/GHSA-rxv8-v965-v333) (`cmd/go`),
+  [CVE-2023-39318](https://github.com/advisories/GHSA-vq7j-gx56-rxjh) (`html/template`),
+  [CVE-2023-39319](https://github.com/advisories/GHSA-vv9m-32rr-3g55) (`html/template`),
+  [CVE-2023-39321](https://github.com/advisories/GHSA-9v7r-x7cv-v437) (`crypto/tls`), and
+  [CVE-2023-39322](https://github.com/advisories/GHSA-892h-r6cr-53g4) (`crypto/tls`) [[GH-261](https://github.com/hashicorp/consul-dataplane/pull/261)]
+
+FEATURES:
+
+* Add -shutdown-drain-listeners, -shutdown-grace-period, -graceful-shutdown-path and -graceful-port flags to configure proxy lifecycle management settings for the Envoy container. [[GH-100](https://github.com/hashicorp/consul-dataplane/pull/100)]
+* Add HTTP server with configurable port and endpoint path for initiating graceful shutdown. [[GH-115](https://github.com/hashicorp/consul-dataplane/pull/115)]
+* Catch SIGTERM and SIGINT to initate graceful shutdown in accordance with proxy lifecycle management configuration. [[GH-130](https://github.com/hashicorp/consul-dataplane/pull/130)]
+* Make consul dataplane handle bootstrap param response for Catalog and Mesh V2 resources [[GH-242](https://github.com/hashicorp/consul-dataplane/pull/242)]
+
+IMPROVEMENTS:
+
+* Add graceful_startup endpoint and postStart hook in order to guarantee that dataplane starts up before application container. [[GH-239](https://github.com/hashicorp/consul-dataplane/pull/239)]
+* Add the `-config-file` flag to support reading configuration options from a JSON file. [[GH-164](https://github.com/hashicorp/consul-dataplane/pull/164)]
+* In order to support Windows, write Envoy bootstrap configuration to a regular file instead of a named pipe. [[GH-188](https://github.com/hashicorp/consul-dataplane/pull/188)]
+* connect: Add capture group labels from Envoy cluster FQDNs to Envoy exported metric labels [[GH-184](https://github.com/hashicorp/consul-dataplane/pull/184)]
+
+BUG FIXES:
+
+* Add support for envoy-extra-args. Fixes [Envoy extra-args annotation crashing consul-dataplane container](https://github.com/hashicorp/consul-k8s/issues/1846). [[GH-133](https://github.com/hashicorp/consul-dataplane/pull/133)]
+* Fix a bug where container user was unable to bind to privileged ports (< 1024). The consul-dataplane container now requires the NET_BIND_SERVICE capability. [[GH-238](https://github.com/hashicorp/consul-dataplane/pull/238)]
+* Fix a bug where exiting envoy would inadvertently throw an error [[GH-175](https://github.com/hashicorp/consul-dataplane/pull/175)]
+* Fix a bug with Envoy potentially starting with incomplete configuration by not waiting enough for initial xDS configuration. [[GH-140](https://github.com/hashicorp/consul-dataplane/pull/140)]
+
 ## 1.2.0 (June 28, 2023)
 
 SECURITY:


### PR DESCRIPTION
Adds changelog entries from 1.3.0-rc and 1.3.0 (listed separately to keep updates clear and matching what went out with release - it would be worth some discussion about how we want to stadardize this with point releases across products going forward and update our release docs accordingly)