### PR TITLE
[NET-5263] Pass query to Envoy when proxying metrics requests

### DIFF
--- a/.changelog/372.txt
+++ b/.changelog/372.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+Propagate merged metrics request query params to Envoy to enable metrics filtering.
+```
+```release-note:bug
+Exclude Prometheus scrape path query params from Envoy path match s.t. it does not break merged metrics request routing.
+```

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -126,6 +126,8 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 		args.PrometheusBackendPort = strconv.Itoa(prom.MergePort)
 	}
 
+	bootstrapConfig.Logger = cdp.logger.Named("bootstrap-config")
+
 	// Note: we pass true for omitDeprecatedTags here - consul-dataplane is clean
 	// slate, and we don't need to maintain this legacy behavior.
 	cfg, err := bootstrapConfig.GenerateJSON(args, true)

--- a/pkg/consuldp/metrics_test.go
+++ b/pkg/consuldp/metrics_test.go
@@ -27,7 +27,9 @@ var (
 	dogStatsdAddr    = "127.0.0.1"
 	envoyMetricsPort = 19000
 	envoyMetricsAddr = "127.0.0.1"
-	envoyMetricsUrl  = fmt.Sprintf("http://%s:%v/stats/prometheus", envoyMetricsAddr, envoyMetricsPort)
+
+	// net/url encodes value-less query params with an '='
+	envoyMetricsUrl = fmt.Sprintf("http://%s:%v/stats/prometheus?usedonly=", envoyMetricsAddr, envoyMetricsPort)
 
 	emptyTags = []metrics.Label{}
 )
@@ -199,7 +201,8 @@ func TestMetricsServerEnabled(t *testing.T) {
 			require.NotEqual(t, port, 0, "test failed to figure out metrics server port")
 			log.Printf("port = %v", port)
 
-			url := fmt.Sprintf("http://127.0.0.1:%d/stats/prometheus", port)
+			// Include a query to test that it is propagated _only_ to Envoy's stats endpoint.
+			url := fmt.Sprintf("http://127.0.0.1:%d/stats/prometheus?usedonly", port)
 			resp, err := http.Get(url)
 			require.NoError(t, err)
 			require.NotNil(t, resp)

--- a/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path-with-query.golden
+++ b/pkg/consuldp/testdata/TestBootstrapConfig/custom-prometheus-scrape-path-with-query.golden
@@ -1,0 +1,255 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "web",
+    "id": "web-proxy",
+    "metadata": {
+      "node_name": "agentless-node",
+      "namespace": "default",
+      "partition": "default"
+    }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576
+        }
+      }
+    ]
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "consul-dataplane",
+        "ignore_health_on_host_removal": false,
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "loadAssignment": {
+          "clusterName": "consul-dataplane",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 1234
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "name": "prometheus_backend",
+        "ignore_health_on_host_removal": false,
+        "connect_timeout": "5s",
+        "type": "STATIC",
+        "http_protocol_options": {},
+        "loadAssignment": {
+          "clusterName": "prometheus_backend",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 20100
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "listeners": [
+      {
+        "name": "envoy_prometheus_metrics_listener",
+        "address": {
+          "socket_address": {
+            "address": "0.0.0.0",
+            "port_value": 20200
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "stat_prefix": "envoy_prometheus_metrics",
+                  "codec_type": "HTTP1",
+                  "route_config": {
+                    "name": "self_admin_route",
+                    "virtual_hosts": [
+                      {
+                        "name": "self_admin",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "path": "/custom/scrape/path"
+                            },
+                            "route": {
+                              "cluster": "prometheus_backend",
+                              "prefix_rewrite": "/stats/prometheus"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "direct_response": {
+                              "status": 404
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+    "stats_tags": [
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:([^.]+)\\.)?[^.]+\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.partition"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.internal[^.]*\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.([^.]+\\.(?:[^.]+\\.)?([^.]+)\\.external\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.peer"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(?:passthrough~)?(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.(([^.]+)(?:\\.[^.]+)?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream_peered\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.peer"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream(?:_peered)?\\.([^.]+(?:\\.([^.]+))?(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.partition"
+      },
+      {
+        "tag_name": "local_cluster",
+        "fixed_value": "web"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "web"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
+        "fixed_value": "default"
+      }
+    ],
+    "use_all_default_tags": true
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "ads": {},
+      "initial_fetch_timeout": "0s",
+      "resource_api_version": "V3"
+    },
+    "ads_config": {
+      "api_type": "DELTA_GRPC",
+      "transport_api_version": "V3",
+      "grpc_services": {
+        "envoy_grpc": {
+          "cluster_name": "consul-dataplane"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Changes proposed in this PR

* Allow passthrough of merged metrics endpoint query params to Envoy's stats endpoint to enable filtering of metrics
* Prevent query in user-defined scrape path from breaking path matching for the merged metrics endpoint

### Considerations

An alternative approach could use explicit config in `consul-dataplane` and the `consul-k8s` Helm chart to set static query parameters to append to Envoy stats requests. That would require more work to implement, and would also limit the ability of multiple consumers (e.g. old + new Prometheus config, or a human/other scrape process) from using different queries to suit their needs.

We could also implement an explicit allow-list for query params. After reviewing the available options in the [docs](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--stats?format=prometheus&usedonly), it seems reasonable to allow users to interact freely with that specific endpoint to take advantage of new features Envoy may offer in the future. While an allow-list could also be added via configuration, this doesn't seem necessary at the moment, and we already don't limit the `envoy_stats_bind_addr` (`/stats`) endpoint today. That said, open to discussion if folks disagree.

### Testing

* Tested locally in `kind` cluster:
```shell
❯ k exec $(get-pod-name api) -c api -- curl -s 'localhost:20200/custom/stats/prometheus' | wc -l
    2364
❯ k exec $(get-pod-name api) -c api -- curl -s 'localhost:20200/custom/stats/prometheus?usedonly=true' | wc -l
     888
```

### Links

* Envoy admin `/stats` endpoint [docs](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--stats?format=prometheus&usedonly) (note that `/stats/prometheus` is an alias for `?format=prometheus`, and other `/stats` query params work for both endpoints)