### PR TITLE
Dockerfile: bump up to ubi-minimal:9.3

### DIFF
--- a/.changelog/373.txt
+++ b/.changelog/373.txt
@@ -1,3 +1,3 @@
 ```release-note:security
- Upgrade OpenShift container images to use `ubi-minimal:9.3` as the base image.
+ Upgrade OpenShift container images to use `ubi9-minimal:9.3` as the base image.
  ```

--- a/.changelog/373.txt
+++ b/.changelog/373.txt
@@ -1,3 +1,3 @@
 ```release-note:security
- Upgrade to use `ubi-minimal:9.3` for OpenShift container images.
+ Upgrade OpenShift container images to use `ubi-minimal:9.3` as the base image.
  ```

--- a/.changelog/373.txt
+++ b/.changelog/373.txt
@@ -1,0 +1,3 @@
+```release-note:security
+ Upgrade to use `ubi-minimal:9.3` for OpenShift container images.
+ ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
 # This image is based on the Red Hat UBI base image, and has the necessary
 # labels, license file, and non-root user.
 # -----------------------------------
-FROM registry.access.redhat.com/ubi9-minimal:9.2 as release-ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.3 as release-ubi
 
 ARG BIN_NAME=consul-dataplane
 ENV BIN_NAME=$BIN_NAME


### PR DESCRIPTION
Dockerfile: bump up to `ubi-minimal:9.3` to remediate vulnerabilities. The current `ubi-minimal:9.2` image is not actively maintained and CVEs fixes are not backported. 