### PR TITLE
Add get-go-version to integrations tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,6 +337,7 @@ jobs:
       - build-docker-default
       - build-docker-ubi-dockerhub
       - get-product-version
+      - get-go-version
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
I missed this when doing the go changes. The change is already on the release branches.