### PR TITLE
Add some release scripts for prepare-release and prepare-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,16 +120,34 @@ copy-bootstrap-config: ## copy bootstrap config
 
 .PHONY: changelog
 changelog: ## build change log
-ifdef LAST_RELEASE_GIT_TAG
+ifdef DP_LAST_RELEASE_GIT_TAG
 	@changelog-build \
-		-last-release $(LAST_RELEASE_GIT_TAG) \
+		-last-release $(DP_LAST_RELEASE_GIT_TAG) \
 		-entries-dir .changelog/ \
 		-changelog-template .changelog/changelog.tmpl \
 		-note-template .changelog/note.tmpl \
 		-this-release $(REVISION)
 else
-	$(error Cannot generate changelog without LAST_RELEASE_GIT_TAG)
+	$(error Cannot generate changelog without DP_LAST_RELEASE_GIT_TAG)
 endif
+
+.PHONY: check-env
+check-env: ## check env
+	@printenv | grep "DP"
+
+.PHONY: prepare-release
+prepare-release:
+ifndef DP_RELEASE_VERSION
+	$(error DP_RELEASE_VERSION is required)
+endif
+	@$(CURDIR)/build-scripts/prepare-release.sh $(CURDIR)/pkg/version/version.go $(DP_RELEASE_VERSION) ""
+
+.PHONY: prepare-dev
+prepare-dev:
+ifndef DP_NEXT_RELEASE_VERSION
+	$(error DP_NEXT_RELEASE_VERSION is required)
+endif
+	@$(CURDIR)/build-scripts/prepare-release.sh $(CURDIR)/pkg/version/version.go $(DP_NEXT_RELEASE_VERSION) "dev"
 
 ##@ Help
 

--- a/build-scripts/prepare-release.sh
+++ b/build-scripts/prepare-release.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+function sed_i {
+	if test "$(uname)" == "Darwin"; then
+		sed -i '' "$@"
+		return $?
+	else
+		sed -i "$@"
+		return $?
+	fi
+}
+
+if test "$(uname)" == "Darwin"; then
+	SED_EXT="-E"
+else
+	SED_EXT="-r"
+fi
+
+VFILE=$1
+VERSION=$2
+PRERELEASE=$3
+
+echo "==> Preparing consul-dataplane for release by updating ${VFILE} with version info: ${VERSION}"
+
+sed_i ${SED_EXT} -e "s/(Version[[:space:]]*=[[:space:]]*)\"[^\"]*\"/\1\"${VERSION}\"/g" -e "s/(VersionPrerelease[[:space:]]*=[[:space:]]*)\"[^\"]*\"/\1\"${PRERELEASE}\"/g" "${VFILE}"


### PR DESCRIPTION
- Added a few make targets to make releasing easier.
- The targets are pretty much copied from consul-k8s and are used for flipping the repo back and forth from dev mode/release mode.
- Once I merge this, I plan to use it to flip all of the release branches back into dev mode. 


