### PR TITLE
[NET-7948] security: update Envoy to 1.28.1

### DIFF
--- a/.changelog/416.txt
+++ b/.changelog/416.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+Update Envoy version from 1.27 to 1.28
+```
+```release-note:security
+Update Envoy version to 1.28.1 to address [CVE-2024-23324](https://github.com/envoyproxy/envoy/security/advisories/GHSA-gq3v-vvhj-96j6), [CVE-2024-23325](https://github.com/envoyproxy/envoy/security/advisories/GHSA-5m7c-mrwr-pm26), [CVE-2024-23322](https://github.com/envoyproxy/envoy/security/advisories/GHSA-6p83-mfmh-qv38), [CVE-2024-23323](https://github.com/envoyproxy/envoy/security/advisories/GHSA-x278-4w4x-r7ch), [CVE-2024-23327](https://github.com/envoyproxy/envoy/security/advisories/GHSA-4h5x-x9vh-m29j), and [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76)
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.27.2 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.28.1 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary
@@ -27,7 +27,8 @@ RUN apt-get update && apt install -y libcap2-bin
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/envoy
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/$BIN_NAME
 
-FROM hashicorp/envoy-fips:1.27.2-fips1402 as envoy-fips-binary
+#TODO: update to 1.28.1 before next release
+FROM hashicorp/envoy-fips:1.28.0-fips1402 as envoy-fips-binary
 
 # Modify the envoy-fips binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-fips-binary


### PR DESCRIPTION
Bump to 1.28.1 on `main` and `release/1.4.x`.