### PR TITLE
[NET-7948] security: update Envoy to 1.26.7

### DIFF
--- a/.changelog/418.txt
+++ b/.changelog/418.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Update Envoy version to 1.26.7 to address [CVE-2024-23324](https://github.com/envoyproxy/envoy/security/advisories/GHSA-gq3v-vvhj-96j6), [CVE-2024-23325](https://github.com/envoyproxy/envoy/security/advisories/GHSA-5m7c-mrwr-pm26), [CVE-2024-23322](https://github.com/envoyproxy/envoy/security/advisories/GHSA-6p83-mfmh-qv38), [CVE-2024-23323](https://github.com/envoyproxy/envoy/security/advisories/GHSA-x278-4w4x-r7ch), [CVE-2024-23327](https://github.com/envoyproxy/envoy/security/advisories/GHSA-4h5x-x9vh-m29j), and [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76) (note: upgrades to Envoy 1.26 for security patches due to 1.25 EOL)
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # envoy-binary pulls in the latest Envoy binary, as Envoy don't publish
 # prebuilt binaries in any other form.
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.25.11 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.26.7 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary


### PR DESCRIPTION
Update from 1.25.11 to 1.26.7 to address multiple CVEs.

Envoy 1.25 has reached EOL, so upgrade to 1.26 is necessary to receive critical security patches.

Based on https://github.com/hashicorp/consul-dataplane/pull/97 and the current state of `release/1.2.x`, it looks like we don't need to make any further changes to dependencies to support this upgrade.