### PR TITLE
[NET-7948] security: update Envoy to 1.27.3 for consul-dataplane 1.3.x 

### DIFF
--- a/.changelog/417.txt
+++ b/.changelog/417.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+ Update Envoy version from 1.27.2 to 1.27.3
+ ```
+ ```release-note:security
+ Update Envoy version to 1.27.3 to address [CVE-2024-23324](https://github.com/envoyproxy/envoy/security/advisories/GHSA-gq3v-vvhj-96j6), [CVE-2024-23325](https://github.com/envoyproxy/envoy/security/advisories/GHSA-5m7c-mrwr-pm26), [CVE-2024-23322](https://github.com/envoyproxy/envoy/security/advisories/GHSA-6p83-mfmh-qv38), [CVE-2024-23323](https://github.com/envoyproxy/envoy/security/advisories/GHSA-x278-4w4x-r7ch), [CVE-2024-23327](https://github.com/envoyproxy/envoy/security/advisories/GHSA-4h5x-x9vh-m29j), and [CVE-2023-44487](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76)
+ ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.27.2 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.27.3 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary


### PR DESCRIPTION
Bump to Enovy 1.27.3 to address CVEs