### PR TITLE
[NET-7991] security: update Envoy to 1.28.1 (FIPS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update && apt install -y libcap2-bin
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/envoy
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/$BIN_NAME
 
-#TODO: update to 1.28.1 before next release
-FROM hashicorp/envoy-fips:1.28.0-fips1402 as envoy-fips-binary
+FROM hashicorp/envoy-fips:1.28.1-fips1402 as envoy-fips-binary
 
 # Modify the envoy-fips binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-fips-binary


### PR DESCRIPTION
Follow-up to 0584963c7d55d3e46473db480cce0f280f48cfc8.