### PR TITLE
[NET-2420] security: add security scans on protected branches

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,63 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+  pull_request:
+    branches:
+      - main
+      - release/**
+
+# cancel existing runs of the same workflow on the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  get-go-version:
+    uses: ./.github/workflows/reusable-get-go-version.yml
+
+  scan:
+    needs:
+    - get-go-version
+    runs-on: ubuntu-latest
+    # The first check ensures this doesn't run on community-contributed PRs, who
+    # won't have the permissions to run this job.
+    if: ${{ (github.repository != 'hashicorp/consul-dataplane' || (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name))
+      && (github.actor != 'dependabot[bot]') && (github.actor != 'hc-github-team-consul-core') }}
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+
+      - name: Clone Security Scanner repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          repository: hashicorp/security-scanner
+          #TODO: replace w/ HASHIBOT_PRODSEC_GITHUB_TOKEN once provisioned
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          path: security-scanner
+          ref: main
+
+      - name: Scan
+        id: scan
+        uses: ./security-scanner
+        with:
+          repository: "$PWD"
+          # See scan.hcl at repository root for config.
+
+      - name: SARIF Output
+        shell: bash
+        run: |
+          cat results.sarif | jq
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@46a6823b81f2d7c67ddf123851eea88365bc8a67 # codeql-bundle-v2.13.5
+        with:
+          sarif_file: results.sarif

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,16 +1,31 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# These scan results are run as part of CRT workflows.
+
+# Un-triaged results will block release. See `security-scanner` docs for more
+# information on how to add `triage` config to unblock releases for specific results.
+# In most cases, we should not need to disable the entire scanner to unblock a release.
+
+# To run manually, install scanner and then from the repository root run
+# `SECURITY_SCANNER_CONFIG_FILE=.release/security-scan.hcl scan ...`
+# To scan a local container, add `local_daemon = true` to the `container` block below.
+# See `security-scanner` docs or run with `--help` for scan target syntax.
+
 container {
   dependencies = true
   alpine_secdb = true
-  secrets      = true
+
+  secrets {
+    all = true
+  }
 }
 
 binary {
-  secrets      = true
   go_modules   = true
   osv          = true
-  oss_index    = false
-  nvd          = false
+
+  secrets {
+    all = true
+  }
 }

--- a/scan.hcl
+++ b/scan.hcl
@@ -1,0 +1,35 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Configuration for security scanner.
+# Run on PRs and pushes to `main` and `release/**` branches.
+# See .github/workflows/security-scan.yml for CI config.
+
+# To run manually, install scanner and then run `scan repository .`
+
+# Scan results are triaged via the GitHub Security tab for this repo.
+# See `security-scanner` docs for more information on how to add `triage` config
+# for specific results or to exclude paths.
+
+# .release/security-scan.hcl controls scanner config for release artifacts, which
+# unlike the scans configured here, will block releases in CRT.
+
+repository {
+  go_modules   = true
+  npm          = true
+  osv          = true
+
+  secrets {
+    all = true
+  }
+
+  triage {
+    suppress {
+      paths = [
+        # Ignore test and local tool modules, which are not included in published
+        # artifacts.
+        "integration-tests/*",
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Changes proposed in this PR

- Enable proactive triage by scanning PRs and merges to protected branches.
- Add exceptions to test and local tooling submodules to improve signal in security scans and simplify triage.
- Add docs and align config to https://github.com/hashicorp/consul-k8s/pull/3628 (no functional changes) for easier maintenance.

See hashicorp/consul#19978 for similar changes in those repos, adapted here.