### PR TITLE
internal/debug: enabled debug server

### DIFF
--- a/.changelog/440.txt
+++ b/.changelog/440.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add debug server for exposing pprof and runtime metrics.
+```

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -29,6 +29,7 @@ type DataplaneConfigFlags struct {
 	DNSServer DNSServerFlags `json:"dnsServer,omitempty"`
 	Telemetry TelemetryFlags `json:"telemetry,omitempty"`
 	Envoy     EnvoyFlags     `json:"envoy,omitempty"`
+	Debug     DebugFlags     `json:"debug,omitempty"`
 }
 
 type ConsulFlags struct {
@@ -145,6 +146,11 @@ type EnvoyFlags struct {
 	StartupGracePeriodSeconds *int `json:"startupGracePeriodSeconds,omitempty"`
 	//Endpoint for graceful startup function.
 	GracefulStartupPath *string `json:"gracefulStartupPath,omitempty"`
+}
+
+type DebugFlags struct {
+	ServerEnabled *bool `json:"serverEnabled,omitempty"`
+	ServerPort    *int  `json:"serverPort,omitempty"`
 }
 
 const (

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -21,15 +21,15 @@ type FlagOpts struct {
 }
 
 type DataplaneConfigFlags struct {
-	Consul    ConsulFlags    `json:"consul,omitempty"`
-	Service   ServiceFlags   `json:"service,omitempty"`
-	Proxy     ProxyFlags     `json:"proxy,omitempty"`
-	Logging   LogFlags       `json:"logging,omitempty"`
-	XDSServer XDSServerFlags `json:"xdsServer,omitempty"`
-	DNSServer DNSServerFlags `json:"dnsServer,omitempty"`
-	Telemetry TelemetryFlags `json:"telemetry,omitempty"`
-	Envoy     EnvoyFlags     `json:"envoy,omitempty"`
-	Debug     DebugFlags     `json:"debug,omitempty"`
+	Consul      ConsulFlags      `json:"consul,omitempty"`
+	Service     ServiceFlags     `json:"service,omitempty"`
+	Proxy       ProxyFlags       `json:"proxy,omitempty"`
+	Logging     LogFlags         `json:"logging,omitempty"`
+	XDSServer   XDSServerFlags   `json:"xdsServer,omitempty"`
+	DNSServer   DNSServerFlags   `json:"dnsServer,omitempty"`
+	Telemetry   TelemetryFlags   `json:"telemetry,omitempty"`
+	Envoy       EnvoyFlags       `json:"envoy,omitempty"`
+	DebugServer DebugServerFlags `json:"debugServer,omitempty"`
 }
 
 type ConsulFlags struct {
@@ -148,9 +148,9 @@ type EnvoyFlags struct {
 	GracefulStartupPath *string `json:"gracefulStartupPath,omitempty"`
 }
 
-type DebugFlags struct {
-	ServerEnabled *bool `json:"serverEnabled,omitempty"`
-	ServerPort    *int  `json:"serverPort,omitempty"`
+type DebugServerFlags struct {
+	BindAddr *string `json:"bindAddress,omitempty"`
+	BindPort *int    `json:"bindPort,omitempty"`
 }
 
 const (
@@ -256,6 +256,10 @@ func buildDefaultConsulDPFlags() (DataplaneConfigFlags, error) {
 			"bindPort": 0
 		},
 		"dnsServer": {
+			"bindAddress": "127.0.0.1",
+			"bindPort": -1
+		},
+		"debugServer": {
 			"bindAddress": "127.0.0.1",
 			"bindPort": -1
 		}
@@ -364,6 +368,10 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 		DNSServer: &consuldp.DNSServerConfig{
 			BindAddr: stringVal(cfg.DNSServer.BindAddr),
 			Port:     intVal(cfg.DNSServer.BindPort),
+		},
+		DebugServer: &consuldp.DebugServer{
+			BindAddress: stringVal(cfg.DebugServer.BindAddr),
+			BindPort:    intVal(cfg.DebugServer.BindPort),
 		},
 	}, nil
 }

--- a/cmd/consul-dataplane/config_test.go
+++ b/cmd/consul-dataplane/config_test.go
@@ -100,6 +100,10 @@ func TestConfigGeneration(t *testing.T) {
 							KeyFile:       "prom-key.pem",
 						},
 					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
+					},
 				}
 			},
 			wantErr: false,
@@ -177,6 +181,10 @@ func TestConfigGeneration(t *testing.T) {
 							CertFile:      "prom-ca-cert.pem",
 							KeyFile:       "prom-key.pem",
 						},
+					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
 					},
 				}
 			},
@@ -282,6 +290,10 @@ func TestConfigGeneration(t *testing.T) {
 							KeyFile:       "prom-key.pem",
 						},
 					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
+					},
 				}
 			},
 			wantErr: false,
@@ -386,6 +398,10 @@ func TestConfigGeneration(t *testing.T) {
 							KeyFile:       "prom-key.pem",
 						},
 					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
+					},
 				}
 			},
 			wantErr: false,
@@ -474,6 +490,10 @@ func TestConfigGeneration(t *testing.T) {
 							CertFile:      "prom-ca-cert.pem",
 							KeyFile:       "prom-key.pem",
 						},
+					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
 					},
 				}
 			},
@@ -570,6 +590,10 @@ func TestConfigGeneration(t *testing.T) {
 							ScrapePath:    "/metrics",
 							MergePort:     20100,
 						},
+					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
 					},
 				}
 			},
@@ -698,6 +722,10 @@ func TestConfigGeneration(t *testing.T) {
 							KeyFile:       "prom-key.pem",
 						},
 					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
+					},
 				}
 			},
 			wantErr: false,
@@ -824,6 +852,10 @@ func TestConfigGeneration(t *testing.T) {
 							CertFile:      "prom-ca-cert.pem",
 							KeyFile:       "prom-key.pem",
 						},
+					},
+					DebugServer: &consuldp.DebugServer{
+						BindAddress: "127.0.0.1",
+						BindPort:    -1,
 					},
 				}
 			},

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -131,8 +131,9 @@ func init() {
 	flags.StringVar(&flagOpts.configFile, "config-file", "", "The json config file for configuring consul data plane")
 
 	// Debug flags.
-	BoolVar(flags, &flagOpts.dataplaneConfig.Debug.ServerEnabled, "debug-server-enabled", "DP_DEBUG_SERVER_ENABLED", "Enabled the local debug server.")
-	IntVar(flags, &flagOpts.dataplaneConfig.Debug.ServerPort, "debug-server-port", "DP_DEBUG_SERVER_PORT", "The HTTP port to expose the debug server on.")
+	StringVar(flags, &flagOpts.dataplaneConfig.DebugServer.BindAddr, "debug-bind-addr", "DP_DEBUG_BIND_ADDR", "The address on which the debug server is available.")
+	IntVar(flags, &flagOpts.dataplaneConfig.DebugServer.BindPort, "debug-bind-port", "DP_DEBUG_BIND_PORT", "The port on which the debug server is available.")
+
 }
 
 // validateFlags performs semantic validation of the flag values
@@ -189,8 +190,8 @@ func run() error {
 		consuldpInstance.GracefulShutdown(cancel)
 	}()
 
-	if *flagOpts.dataplaneConfig.Debug.ServerEnabled {
-		go debug.EnableDebugServer(ctx, *flagOpts.dataplaneConfig.Debug.ServerPort)
+	if *flagOpts.dataplaneConfig.DebugServer.BindPort >= 0 {
+		go debug.EnableDebugServer(ctx, *flagOpts.dataplaneConfig.DebugServer.BindAddr, *flagOpts.dataplaneConfig.DebugServer.BindPort)
 	}
 
 	return consuldpInstance.Run(ctx)

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/hashicorp/consul-dataplane/internal/debug"
 	"github.com/hashicorp/consul-dataplane/pkg/consuldp"
 	"github.com/hashicorp/consul-dataplane/pkg/version"
 )
@@ -128,6 +129,10 @@ func init() {
 	BoolVar(flags, &flagOpts.dataplaneConfig.Envoy.DumpEnvoyConfigOnExitEnabled, "dump-envoy-config-on-exit", "DP_DUMP_ENVOY_CONFIG_ON_EXIT", "Call the Envoy /config_dump endpoint during consul-dataplane controlled shutdown.")
 
 	flags.StringVar(&flagOpts.configFile, "config-file", "", "The json config file for configuring consul data plane")
+
+	// Debug flags.
+	BoolVar(flags, &flagOpts.dataplaneConfig.Debug.ServerEnabled, "debug-server-enabled", "DP_DEBUG_SERVER_ENABLED", "Enabled the local debug server.")
+	IntVar(flags, &flagOpts.dataplaneConfig.Debug.ServerPort, "debug-server-port", "DP_DEBUG_SERVER_PORT", "The HTTP port to expose the debug server on.")
 }
 
 // validateFlags performs semantic validation of the flag values
@@ -183,6 +188,10 @@ func run() error {
 
 		consuldpInstance.GracefulShutdown(cancel)
 	}()
+
+	if *flagOpts.dataplaneConfig.Debug.ServerEnabled {
+		go debug.EnableDebugServer(ctx, *flagOpts.dataplaneConfig.Debug.ServerPort)
+	}
 
 	return consuldpInstance.Run(ctx)
 }

--- a/internal/debug/metrics.go
+++ b/internal/debug/metrics.go
@@ -3,6 +3,7 @@ package debug
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"time"
@@ -13,7 +14,7 @@ import (
 
 // EnableDebugServer starts a local HTTP server on a given port.
 // By default, it will register pprof and runtime metrics endpoints.
-func EnableDebugServer(ctx context.Context, port int) {
+func EnableDebugServer(ctx context.Context, addr string, port int) {
 	log := hclog.FromContext(ctx).Named("debug_server")
 
 	router := http.NewServeMux()
@@ -28,17 +29,20 @@ func EnableDebugServer(ctx context.Context, port int) {
 	// Expose default runtime metrics.
 	router.Handle("/debug/metrics", promhttp.Handler())
 
-	addr := fmt.Sprintf(":%d", port)
 	srv := &http.Server{
-		Addr:         addr,
 		Handler:      router,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}
 
 	go func() {
-		log.Info("starting local debug server", "address", addr)
-		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr, port))
+		if err != nil {
+			log.Error("local debug server tcp error", "error", err)
+			return
+		}
+		log.Info("starting local debug server", "address", ln.Addr().String())
+		if err := srv.Serve(ln); err != http.ErrServerClosed {
 			log.Error("local debug server error", "error", err)
 			return
 		}

--- a/internal/debug/metrics.go
+++ b/internal/debug/metrics.go
@@ -1,0 +1,50 @@
+package debug
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// EnableDebugServer starts a local HTTP server on a given port.
+// By default, it will register pprof and runtime metrics endpoints.
+func EnableDebugServer(ctx context.Context, port int) {
+	log := hclog.FromContext(ctx).Named("debug_server")
+
+	router := http.NewServeMux()
+
+	// Configure debug endpoints.
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// Expose the registered metrics via HTTP.
+	router.Handle("/debug/metrics", promhttp.Handler())
+
+	addr := fmt.Sprintf(":%d", port)
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      router,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		log.Info("starting local debug server", "address", addr)
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Error("local debug server error", "error", err)
+			return
+		}
+	}()
+
+	// Wait for service to exit and shutdown.
+	<-ctx.Done()
+	_ = srv.Shutdown(context.Background())
+}

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -313,14 +313,23 @@ type XDSServer struct {
 	BindPort int
 }
 
+// DebugServer contains the configuration of the debug server.
+type DebugServer struct {
+	// BindAddress is the address on which the debug server will be available.
+	BindAddress string
+	// BindPort is the address on which the debug port will be available.
+	BindPort int
+}
+
 // Config is the configuration used by consul-dataplane, consolidated
 // from various sources - CLI flags, env vars, config file settings.
 type Config struct {
-	DNSServer *DNSServerConfig
-	Consul    *ConsulConfig
-	Proxy     *ProxyConfig
-	Logging   *LoggingConfig
-	Telemetry *TelemetryConfig
-	Envoy     *EnvoyConfig
-	XDSServer *XDSServer
+	DNSServer   *DNSServerConfig
+	Consul      *ConsulConfig
+	Proxy       *ProxyConfig
+	Logging     *LoggingConfig
+	Telemetry   *TelemetryConfig
+	Envoy       *EnvoyConfig
+	XDSServer   *XDSServer
+	DebugServer *DebugServer
 }


### PR DESCRIPTION
### Description
This PR adds a configurable HTTP "debug" server exposing pprof and runtime metrics. AFAICT, we do not currently have something like this in the existing code.

### Thoughts
- Maybe we could use the existing [`TelemetryConfig`](https://github.com/hashicorp/consul-dataplane/blob/main/pkg/consuldp/config.go#L231) instead of adding a new `DebugServer` config option?
- I decided to add this as a completely separate `/debug/*` server instead of bolting onto the current Prom server. Open to not doing this and bundling it all together.