### PR TITLE
[NET-9002] security: update Envoy to 1.27.5

### DIFF
--- a/.changelog/498.txt
+++ b/.changelog/498.txt
@@ -1,0 +1,4 @@
+```release-note:security
+Upgrade to support Envoy `1.27.5`. This resolves CVE
+[CVE-2024-32475](https://nvd.nist.gov/vuln/detail/CVE-2024-32475).
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.26.8 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.27.5 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary
@@ -27,7 +27,7 @@ RUN apt-get update && apt install -y libcap2-bin
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/envoy
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/$BIN_NAME
 
-FROM hashicorp/envoy-fips:1.26.7-fips1402 as envoy-fips-binary
+FROM hashicorp/envoy-fips:1.27.5-fips1402 as envoy-fips-binary
 
 # Modify the envoy-fips binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-fips-binary


### PR DESCRIPTION
Resolves CVE-2024-32475.

Note that Envoy 1.26 is EOL, therefore this change updates the minor version to 1.27. Previously, `consul-dataplane` 1.2.x tracked Envoy 1.26.