### PR TITLE
[NET-9002] security: update Envoy to 1.27.5

### DIFF
--- a/.changelog/499.txt
+++ b/.changelog/499.txt
@@ -1,0 +1,4 @@
+```release-note:security
+Upgrade to support Envoy `1.27.5`. This resolves CVE
+[CVE-2024-32475](https://nvd.nist.gov/vuln/detail/CVE-2024-32475).
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # envoy-binary pulls in the latest Envoy binary, as Envoy don't publish
 # prebuilt binaries in any other form.
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.26.8 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.27.5 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary


### PR DESCRIPTION
Resolves CVE-2024-32475.

Note that Envoy 1.26 is EOL, therefore this change updates the minor version to 1.27. Previously, `consul-dataplane` 1.1.x tracked Envoy 1.26.