### PR TITLE
Add Consul 1.19 int test to 1.5.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,12 +355,12 @@ jobs:
         server:
           - version: v1.15.0-dev
             image: hashicorppreview/consul:1.15-dev
-          - version: v1.16.0-dev
-            image: hashicorppreview/consul:1.16-dev
           - version: v1.17.0-dev
             image: hashicorppreview/consul:1.17-dev
           - version: v1.18.0-dev
             image: hashicorppreview/consul:1.18-dev
+          - version: v1.19.0-dev
+            image: hashicorppreview/consul:1.19-dev
         dataplane:
           - image_suffix: ""
             docker_target: "release-default"


### PR DESCRIPTION
In addition to `main`, we should be testing these versions together on the release branch.

Drop 1.16, which is retired as of 1.5.

See https://github.com/hashicorp/consul-dataplane/pull/522 for `main` updates.