### PR TITLE
Backport of Update envoy version in dockerfile into release/1.5.0

### DIFF
--- a/.changelog/533.txt
+++ b/.changelog/533.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Upgrade to support Envoy `1.29.5`.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.29.4 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.29.5 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-binary
@@ -27,7 +27,7 @@ RUN apt-get update && apt install -y libcap2-bin
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/envoy
 RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/$BIN_NAME
 
-FROM hashicorp/envoy-fips:1.29.4-fips1402 as envoy-fips-binary
+FROM hashicorp/envoy-fips:1.29.5-fips1402 as envoy-fips-binary
 
 # Modify the envoy-fips binary to be able to bind to privileged ports (< 1024).
 FROM debian:bullseye-slim AS setcap-envoy-fips-binary


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/consul-dataplane/pull/533