### PR TITLE
[NET-10001] test: replace deprecated google/pause container

### DIFF
--- a/integration-tests/helpers/pod.go
+++ b/integration-tests/helpers/pod.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const pauseContainerImage = "google/pause:asm"
+const pauseContainerImage = "registry.k8s.io/pause"
 
 type Pod struct {
 	*Container


### PR DESCRIPTION
This container is 9+ years unmaintained and no longer pullable by default due to using a deprecated manifest format. Replacing with a common alternative pause image.

I'll backport this manually to 1.5.0 as well.