### PR TITLE
Backport of [NET-10001] test: replace deprecated google/pause container into release/1.5.0

### DIFF
--- a/integration-tests/helpers/pod.go
+++ b/integration-tests/helpers/pod.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const pauseContainerImage = "google/pause:asm"
+const pauseContainerImage = "registry.k8s.io/pause"
 
 type Pod struct {
 	*Container


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/consul-dataplane/pull/545 into release/1.5.0