### PR TITLE
ci: add integration-tests summary job for required check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,3 +398,17 @@ jobs:
       - name: Check for failures
         if: ${{ steps.run-tests.outcome != 'success' }}
         run: exit 1
+
+  integration-tests-success:
+    needs:
+      - integration-tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: evaluate upstream job results
+        run: |
+          # exit 1 if failure or cancelled result for any upstream job
+          if printf '${{ toJSON(needs) }}' | grep -E -i '\"result\": \"(failure|cancelled)\"'; then
+            printf "Tests failed or workflow cancelled:\n\n${{ toJSON(needs) }}"
+            exit 1
+          fi


### PR DESCRIPTION
Fan-in results of the matrix integration tests so we can require them in branch protections.