### PR TITLE
ci: add conditional skip for docs changes

### DIFF
--- a/.github/scripts/check_skip_ci.sh
+++ b/.github/scripts/check_skip_ci.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+# Get the list of changed files
+# Using `git merge-base` ensures that we're always comparing against the correct branch point.
+#For example, given the commits:
+#
+# A---B---C---D---W---X---Y---Z # origin/main
+#             \---E---F         # feature/branch
+#
+# ... `git merge-base origin/$SKIP_CHECK_BRANCH HEAD` would return commit `D`
+# `...HEAD` specifies from the common ancestor to the latest commit on the current branch (HEAD)..
+files_to_check=$(git diff --name-only "$(git merge-base origin/$SKIP_CHECK_BRANCH HEAD~)"...HEAD)
+
+# Define the directories to check
+skipped_directories=("_doc/" ".changelog/")
+
+# Loop through the changed files and find directories/files outside the skipped ones
+files_to_check_array=($files_to_check)
+for file_to_check in "${files_to_check_array[@]}"; do
+	file_is_skipped=false
+	echo "checking file: $file_to_check"
+
+	# Allow changes to:
+	# - This script
+	# - Files in the skipped directories
+	# - Markdown files
+	for dir in "${skipped_directories[@]}"; do
+		if [[ "$file_to_check" == */check_skip_ci.sh ]] ||
+		   [[ "$file_to_check" == "$dir"* ]] ||
+		   [[ "$file_to_check" == *.md ]]; then
+			file_is_skipped=true
+			break
+		fi
+	done
+
+	if [ "$file_is_skipped" != "true" ]; then
+		echo -e "non-skippable file changed: $file_to_check"
+		echo "Changes detected in non-documentation files - will not skip tests and build"
+        echo "skip-ci=false" >> "$GITHUB_OUTPUT"
+		exit 0 ## if file is outside of the skipped_directory exit script
+	fi
+done
+
+echo "Changes detected in only documentation files - skipping tests and build"
+echo "skip-ci=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,19 @@ env:
   PKG_NAME: "consul-dataplane"
 
 jobs:
+  conditional-skip:
+    uses: ./.github/workflows/reusable-conditional-skip.yml
+
   get-go-version:
+    # Cascades down to test jobs
+    needs: [conditional-skip]
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   get-product-version:
+    # Cascades down to test jobs
+    needs: [conditional-skip]
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
@@ -401,9 +410,10 @@ jobs:
 
   integration-tests-success:
     needs:
+      - conditional-skip
       - integration-tests
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.conditional-skip.outputs.skip-ci != 'true'
     steps:
       - name: evaluate upstream job results
         run: |

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -8,7 +8,13 @@ on:
   pull_request:
 
 jobs:
+  conditional-skip:
+    uses: ./.github/workflows/reusable-conditional-skip.yml
+
   get-go-version:
+    # Cascades down to test jobs
+    needs: [conditional-skip]
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   unit-tests:

--- a/.github/workflows/reusable-conditional-skip.yml
+++ b/.github/workflows/reusable-conditional-skip.yml
@@ -1,0 +1,24 @@
+name: conditional-skip
+
+on:
+  workflow_call:
+    outputs:
+      skip-ci:
+        description: "Whether we should skip build and test jobs"
+        value: ${{ jobs.check-skip.outputs.skip-ci }}
+
+jobs:
+  check-skip:
+    runs-on: ubuntu-latest
+    name: Check whether to skip build and tests
+    outputs:
+      skip-ci: ${{ steps.check-changed-files.outputs.skip-ci }}
+    env:
+      SKIP_CHECK_BRANCH: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+      - name: Check changed files
+        id: check-changed-files
+        run: ./.github/scripts/check_skip_ci.sh

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,7 +16,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  conditional-skip:
+    uses: ./.github/workflows/reusable-conditional-skip.yml
+
   get-go-version:
+    # Cascades down to test jobs
+    needs: [conditional-skip]
+    if: needs.conditional-skip.outputs.skip-ci != 'true'
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   scan:


### PR DESCRIPTION
[Similar to `consul`](https://github.com/hashicorp/consul/blob/e9c983f36107b044fcd889f738b3d5ba2b922e7a/.github/workflows/go-tests.yml#L33), skip build and tests if we're only changing docs.

This should help speed up releases and daily work quick-fixes.

```shell
❯ SKIP_CHECK_BRANCH=zalimeni/conditional-skip-ci GITHUB_OUTPUT="../GITHUB_OUTPUT" .github/scripts/check_skip_ci.sh
checking file: .changelog/100.txt
checking file: .github/scripts/check_skip_ci.sh
checking file: README.md
Changes detected in only documentation files - skipping tests and build
```
After adding a code change:
```shell
❯ SKIP_CHECK_BRANCH=zalimeni/conditional-skip-ci GITHUB_OUTPUT="../GITHUB_OUTPUT" .github/scripts/check_skip_ci.sh
checking file: .changelog/100.txt
checking file: .github/scripts/check_skip_ci.sh
checking file: README.md
checking file: cmd/consul-dataplane/main.go
non-skippable file changed: cmd/consul-dataplane/main.go
Changes detected in non-documentation files - will not skip tests and build
```