### PR TITLE
NET-10195 - allow consul dataplane to be run as a DNS proxy without Envoy or XDS

### DIFF
--- a/.changelog/571.txt
+++ b/.changelog/571.txt
@@ -1,0 +1,9 @@
+```release-note:feature
+Added the ability to set the `-mode` flag. Options available are `sidecar` and `dns-proxy`. The system defaults to `sidecar`.
+When set to `sidecar`:
+- DNS Server, xDS Server, and Envoy are enabled.
+- The system validates that `-consul-dns-bind-addr` and equivalent environment variable must be set to the loopback address.
+When set to `dns-proxy`:
+- Only DNS Server is enabled. xDS Server and Envoy are disabled.
+- `consul-dns-bind-addr` and equivalent environment variable can be set to other values besides the loopback address.
+```

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ docker-run: docker ## run the image of $(TAG)
 
 .PHONY: dev-docker
 dev-docker: docker ## build docker image and tag the image to local
+	echo '$(ARCH)'
 	docker tag '$(PRODUCT_NAME):$(VERSION)'  '$(PRODUCT_NAME):local'
 
 ##@ Testing

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -97,11 +97,13 @@ type ProxyFlags struct {
 }
 
 type XDSServerFlags struct {
+	Enabled  *bool   `json:"enabled,omitempty"`
 	BindAddr *string `json:"bindAddress,omitempty"`
 	BindPort *int    `json:"bindPort,omitempty"`
 }
 
 type DNSServerFlags struct {
+	Enabled  *bool   `json:"enabled,omitempty"`
 	BindAddr *string `json:"bindAddress,omitempty"`
 	BindPort *int    `json:"bindPort,omitempty"`
 }
@@ -128,6 +130,7 @@ type PrometheusTelemetryFlags struct {
 }
 
 type EnvoyFlags struct {
+	Enabled          *bool   `json:"enabled,omitempty"`
 	AdminBindAddr    *string `json:"adminBindAddress,omitempty"`
 	AdminBindPort    *int    `json:"adminBindPort,omitempty"`
 	ReadyBindAddr    *string `json:"readyBindAddress,omitempty"`
@@ -231,6 +234,7 @@ func buildDefaultConsulDPFlags() (DataplaneConfigFlags, error) {
 			}
 		},
 		"envoy": {
+			"enabled": true,
 			"adminBindAddress": "127.0.0.1",
 			"adminBindPort": 19000,
 			"readyBindPort": 0,
@@ -246,10 +250,12 @@ func buildDefaultConsulDPFlags() (DataplaneConfigFlags, error) {
 			"startupGracePeriodSeconds": 0
 		},
 		"xdsServer": {
+			"enabled": true,
 			"bindAddress": "127.0.0.1",
 			"bindPort": 0
 		},
 		"dnsServer": {
+			"enabled": true,
 			"bindAddress": "127.0.0.1",
 			"bindPort": -1
 		}
@@ -323,6 +329,7 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 			LogLevel: strings.ToUpper(stringVal(cfg.Logging.LogLevel)),
 		},
 		Envoy: &consuldp.EnvoyConfig{
+			Enabled:                       boolVal(cfg.Envoy.Enabled),
 			AdminBindAddress:              stringVal(cfg.Envoy.AdminBindAddr),
 			AdminBindPort:                 intVal(cfg.Envoy.AdminBindPort),
 			ReadyBindAddress:              stringVal(cfg.Envoy.ReadyBindAddr),
@@ -352,10 +359,12 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 			},
 		},
 		XDSServer: &consuldp.XDSServer{
+			Enabled:     boolVal(cfg.XDSServer.Enabled),
 			BindAddress: stringVal(cfg.XDSServer.BindAddr),
 			BindPort:    intVal(cfg.XDSServer.BindPort),
 		},
 		DNSServer: &consuldp.DNSServerConfig{
+			Enabled:  boolVal(cfg.DNSServer.Enabled),
 			BindAddr: stringVal(cfg.DNSServer.BindAddr),
 			Port:     intVal(cfg.DNSServer.BindPort),
 		},

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -233,7 +233,6 @@ func buildDefaultConsulDPFlags() (DataplaneConfigFlags, error) {
 			}
 		},
 		"envoy": {
-			"enabled": true,
 			"adminBindAddress": "127.0.0.1",
 			"adminBindPort": 19000,
 			"readyBindPort": 0,
@@ -249,12 +248,10 @@ func buildDefaultConsulDPFlags() (DataplaneConfigFlags, error) {
 			"startupGracePeriodSeconds": 0
 		},
 		"xdsServer": {
-			"enabled": true,
 			"bindAddress": "127.0.0.1",
 			"bindPort": 0
 		},
 		"dnsServer": {
-			"enabled": true,
 			"bindAddress": "127.0.0.1",
 			"bindPort": -1
 		}

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -21,6 +21,7 @@ type FlagOpts struct {
 }
 
 type DataplaneConfigFlags struct {
+	Mode      *string        `json:"mode,omitempty"`
 	Consul    ConsulFlags    `json:"consul,omitempty"`
 	Service   ServiceFlags   `json:"service,omitempty"`
 	Proxy     ProxyFlags     `json:"proxy,omitempty"`
@@ -97,13 +98,11 @@ type ProxyFlags struct {
 }
 
 type XDSServerFlags struct {
-	Enabled  *bool   `json:"enabled,omitempty"`
 	BindAddr *string `json:"bindAddress,omitempty"`
 	BindPort *int    `json:"bindPort,omitempty"`
 }
 
 type DNSServerFlags struct {
-	Enabled  *bool   `json:"enabled,omitempty"`
 	BindAddr *string `json:"bindAddress,omitempty"`
 	BindPort *int    `json:"bindPort,omitempty"`
 }
@@ -130,7 +129,6 @@ type PrometheusTelemetryFlags struct {
 }
 
 type EnvoyFlags struct {
-	Enabled          *bool   `json:"enabled,omitempty"`
 	AdminBindAddr    *string `json:"adminBindAddress,omitempty"`
 	AdminBindPort    *int    `json:"adminBindPort,omitempty"`
 	ReadyBindAddr    *string `json:"readyBindAddress,omitempty"`
@@ -212,6 +210,7 @@ func (f *FlagOpts) buildConfigFromFile() (DataplaneConfigFlags, error) {
 func buildDefaultConsulDPFlags() (DataplaneConfigFlags, error) {
 	data := `
 	{
+		"mode": "sidecar",
 		"consul": {
 			"grpcPort": 8502,
 			"serverWatchDisabled": false,
@@ -322,6 +321,7 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 				InsecureSkipVerify: boolVal(cfg.Consul.TLS.InsecureSkipVerify),
 			},
 		},
+		Mode:  consuldp.ModeType(stringVal(cfg.Mode)),
 		Proxy: &proxyCfg,
 		Logging: &consuldp.LoggingConfig{
 			Name:     DefaultLogName,
@@ -329,7 +329,6 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 			LogLevel: strings.ToUpper(stringVal(cfg.Logging.LogLevel)),
 		},
 		Envoy: &consuldp.EnvoyConfig{
-			Enabled:                       boolVal(cfg.Envoy.Enabled),
 			AdminBindAddress:              stringVal(cfg.Envoy.AdminBindAddr),
 			AdminBindPort:                 intVal(cfg.Envoy.AdminBindPort),
 			ReadyBindAddress:              stringVal(cfg.Envoy.ReadyBindAddr),
@@ -359,12 +358,10 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 			},
 		},
 		XDSServer: &consuldp.XDSServer{
-			Enabled:     boolVal(cfg.XDSServer.Enabled),
 			BindAddress: stringVal(cfg.XDSServer.BindAddr),
 			BindPort:    intVal(cfg.XDSServer.BindPort),
 		},
 		DNSServer: &consuldp.DNSServerConfig{
-			Enabled:  boolVal(cfg.DNSServer.Enabled),
 			BindAddr: stringVal(cfg.DNSServer.BindAddr),
 			Port:     intVal(cfg.DNSServer.BindPort),
 		},

--- a/cmd/consul-dataplane/config_test.go
+++ b/cmd/consul-dataplane/config_test.go
@@ -205,7 +205,6 @@ func TestConfigGeneration(t *testing.T) {
 				opts.dataplaneConfig.DNSServer.BindAddr = strReference("127.0.0.2")
 				opts.dataplaneConfig.XDSServer.BindPort = intReference(6060)
 				opts.dataplaneConfig.Envoy.DumpEnvoyConfigOnExitEnabled = boolReference(true)
-
 				return opts, nil
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
@@ -743,15 +742,8 @@ func TestConfigGeneration(t *testing.T) {
 					  "partition": "default"
 					},
 					"envoy": {
-					  "enabled": false,
 					  "adminBindAddress": "127.0.0.1",
 					  "adminBindPort": 19000
-					},
-					"xdsServer": {
-					  "enabled": false
-					},
-					"dnsServer": {
-					  "enabled": false
 					},
 					"logging": {
 					  "logLevel": "warn",

--- a/cmd/consul-dataplane/config_test.go
+++ b/cmd/consul-dataplane/config_test.go
@@ -69,14 +69,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -147,14 +150,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -202,6 +208,10 @@ func TestConfigGeneration(t *testing.T) {
 				opts.dataplaneConfig.DNSServer.BindAddr = strReference("127.0.0.2")
 				opts.dataplaneConfig.XDSServer.BindPort = intReference(6060)
 				opts.dataplaneConfig.Envoy.DumpEnvoyConfigOnExitEnabled = boolReference(true)
+				opts.dataplaneConfig.Envoy.Enabled = boolReference(false)
+				opts.dataplaneConfig.XDSServer.Enabled = boolReference(false)
+				opts.dataplaneConfig.DNSServer.Enabled = boolReference(false)
+
 				return opts, nil
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
@@ -250,14 +260,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  false,
 						BindAddr: "127.0.0.2",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     false,
 						BindAddress: "127.0.1.0",
 						BindPort:    6060,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       false,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -354,14 +367,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  true,
 						BindAddr: "127.0.0.2",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    6060,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -444,14 +460,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    6060,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -500,8 +519,15 @@ func TestConfigGeneration(t *testing.T) {
 					  "partition": "default"
 					},
 					"envoy": {
+					  "enabled": false,
 					  "adminBindAddress": "127.0.0.1",
 					  "adminBindPort": 19000
+					},
+					"xdsServer": {
+					  "enabled": false
+					},
+					"dnsServer": {
+					  "enabled": false
 					},
 					"logging": {
 					  "logLevel": "info",
@@ -543,14 +569,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "INFO",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  false,
 						BindAddr: "127.0.0.1",
 						Port:     -1,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     false,
 						BindAddress: "127.0.0.1",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       false,
 						AdminBindAddress:              "127.0.0.1",
 						AdminBindPort:                 19000,
 						ReadyBindPort:                 0,
@@ -666,14 +695,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "INFO",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -716,6 +748,9 @@ func TestConfigGeneration(t *testing.T) {
 				opts.dataplaneConfig.Consul.Credentials.Login.Meta = map[string]string{
 					"key1": "value1",
 				}
+				opts.dataplaneConfig.Envoy.Enabled = boolReference(true)
+				opts.dataplaneConfig.XDSServer.Enabled = boolReference(true)
+				opts.dataplaneConfig.DNSServer.Enabled = boolReference(true)
 
 				return opts, nil
 			},
@@ -733,8 +768,15 @@ func TestConfigGeneration(t *testing.T) {
 					  "partition": "default"
 					},
 					"envoy": {
+					  "enabled": false,
 					  "adminBindAddress": "127.0.0.1",
 					  "adminBindPort": 19000
+					},
+					"xdsServer": {
+					  "enabled": false
+					},
+					"dnsServer": {
+					  "enabled": false
 					},
 					"logging": {
 					  "logLevel": "warn",
@@ -793,14 +835,17 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "INFO",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
+						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
+						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
+						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",

--- a/cmd/consul-dataplane/config_test.go
+++ b/cmd/consul-dataplane/config_test.go
@@ -33,6 +33,7 @@ func TestConfigGeneration(t *testing.T) {
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeSidecar,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
 						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
@@ -69,17 +70,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -114,6 +112,7 @@ func TestConfigGeneration(t *testing.T) {
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeSidecar,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
 						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
@@ -150,17 +149,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -195,6 +191,7 @@ func TestConfigGeneration(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
+				opts.dataplaneConfig.Mode = strReference("dns-proxy")
 				opts.dataplaneConfig.Consul.Credentials.Login.BearerTokenPath = strReference("/consul/bearertokenpath/")
 				opts.dataplaneConfig.Consul.Credentials.Login.Datacenter = strReference("dc100")
 				opts.dataplaneConfig.Consul.Credentials.Login.Meta = map[string]string{
@@ -208,14 +205,12 @@ func TestConfigGeneration(t *testing.T) {
 				opts.dataplaneConfig.DNSServer.BindAddr = strReference("127.0.0.2")
 				opts.dataplaneConfig.XDSServer.BindPort = intReference(6060)
 				opts.dataplaneConfig.Envoy.DumpEnvoyConfigOnExitEnabled = boolReference(true)
-				opts.dataplaneConfig.Envoy.Enabled = boolReference(false)
-				opts.dataplaneConfig.XDSServer.Enabled = boolReference(false)
-				opts.dataplaneConfig.DNSServer.Enabled = boolReference(false)
 
 				return opts, nil
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeDNSProxy,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
 						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
@@ -260,17 +255,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  false,
 						BindAddr: "127.0.0.2",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     false,
 						BindAddress: "127.0.1.0",
 						BindPort:    6060,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       false,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -323,6 +315,7 @@ func TestConfigGeneration(t *testing.T) {
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeSidecar,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
 						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
@@ -367,17 +360,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  true,
 						BindAddr: "127.0.0.2",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    6060,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -424,6 +414,7 @@ func TestConfigGeneration(t *testing.T) {
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeSidecar,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
 						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
@@ -460,17 +451,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "WARN",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    6060,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -519,15 +507,8 @@ func TestConfigGeneration(t *testing.T) {
 					  "partition": "default"
 					},
 					"envoy": {
-					  "enabled": false,
 					  "adminBindAddress": "127.0.0.1",
 					  "adminBindPort": 19000
-					},
-					"xdsServer": {
-					  "enabled": false
-					},
-					"dnsServer": {
-					  "enabled": false
 					},
 					"logging": {
 					  "logLevel": "info",
@@ -547,6 +528,7 @@ func TestConfigGeneration(t *testing.T) {
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeSidecar,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           "consul_server.dc1",
 						GRPCPort:            8502,
@@ -569,17 +551,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "INFO",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  false,
 						BindAddr: "127.0.0.1",
 						Port:     -1,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     false,
 						BindAddress: "127.0.0.1",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       false,
 						AdminBindAddress:              "127.0.0.1",
 						AdminBindPort:                 19000,
 						ReadyBindPort:                 0,
@@ -656,6 +635,7 @@ func TestConfigGeneration(t *testing.T) {
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeSidecar,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
 						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
@@ -695,17 +675,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "INFO",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",
@@ -738,6 +715,7 @@ func TestConfigGeneration(t *testing.T) {
 			desc: "test whether CLI flag values override the file values with proxy flags",
 			flagOpts: func() (*FlagOpts, error) {
 				opts, err := generateFlagOptsWithProxyFlags()
+				opts.dataplaneConfig.Mode = strReference("dns-proxy")
 				if err != nil {
 					return nil, err
 				}
@@ -748,9 +726,6 @@ func TestConfigGeneration(t *testing.T) {
 				opts.dataplaneConfig.Consul.Credentials.Login.Meta = map[string]string{
 					"key1": "value1",
 				}
-				opts.dataplaneConfig.Envoy.Enabled = boolReference(true)
-				opts.dataplaneConfig.XDSServer.Enabled = boolReference(true)
-				opts.dataplaneConfig.DNSServer.Enabled = boolReference(true)
 
 				return opts, nil
 			},
@@ -796,6 +771,7 @@ func TestConfigGeneration(t *testing.T) {
 			},
 			makeExpectedCfg: func(flagOpts *FlagOpts) *consuldp.Config {
 				return &consuldp.Config{
+					Mode: consuldp.ModeTypeDNSProxy,
 					Consul: &consuldp.ConsulConfig{
 						Addresses:           stringVal(flagOpts.dataplaneConfig.Consul.Addresses),
 						GRPCPort:            intVal(flagOpts.dataplaneConfig.Consul.GRPCPort),
@@ -835,17 +811,14 @@ func TestConfigGeneration(t *testing.T) {
 						LogLevel: "INFO",
 					},
 					DNSServer: &consuldp.DNSServerConfig{
-						Enabled:  true,
 						BindAddr: "127.0.0.1",
 						Port:     8604,
 					},
 					XDSServer: &consuldp.XDSServer{
-						Enabled:     true,
 						BindAddress: "127.0.1.0",
 						BindPort:    0,
 					},
 					Envoy: &consuldp.EnvoyConfig{
-						Enabled:                       true,
 						AdminBindAddress:              "127.0.1.0",
 						AdminBindPort:                 18000,
 						ReadyBindAddress:              "127.0.1.0",

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -28,8 +28,8 @@ func init() {
 	flags.BoolVar(&flagOpts.printVersion, "version", false, "Prints the current version of consul-dataplane.")
 
 	StringVar(flags, &flagOpts.dataplaneConfig.Mode, "mode", "DP_MODE", "dataplane mode. Value can be:\n"+
-		"1. sidecar - for use when running as a sidecar to Consul services with xDS Server, Envoy, and DNS Server running; OR\n"+
-		"2. dns-proxy - for use a standalone application where DNS Server runs, but Envoy and xDS Server are enabled.\n")
+		"1. sidecar - used when running as a sidecar to Consul services with xDS Server, Envoy, and DNS Server running; OR\n"+
+		"2. dns-proxy - used when running as a standalone application where DNS Server runs, but Envoy and xDS Server are enabled.\n")
 
 	StringVar(flags, &flagOpts.dataplaneConfig.Consul.Addresses, "addresses", "DP_CONSUL_ADDRESSES", "Consul server gRPC addresses. Value can be:\n"+
 		"1. A DNS name that resolves to server addresses or the DNS name of a load balancer in front of the Consul servers; OR\n"+

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -27,6 +27,10 @@ func init() {
 	flagOpts = &FlagOpts{}
 	flags.BoolVar(&flagOpts.printVersion, "version", false, "Prints the current version of consul-dataplane.")
 
+	StringVar(flags, &flagOpts.dataplaneConfig.Mode, "mode", "DP_MODE", "dataplane mode. Value can be:\n"+
+		"1. sidecar - for use when running as a sidecar to Consul services with xDS Server, Envoy, and DNS Server running; OR\n"+
+		"2. dns-proxy - for use a standalone application where DNS Server runs, but Envoy and xDS Server are enabled.\n")
+
 	StringVar(flags, &flagOpts.dataplaneConfig.Consul.Addresses, "addresses", "DP_CONSUL_ADDRESSES", "Consul server gRPC addresses. Value can be:\n"+
 		"1. A DNS name that resolves to server addresses or the DNS name of a load balancer in front of the Consul servers; OR\n"+
 		"2. An executable command in the format, 'exec=<executable with optional args>'. The executable\n"+
@@ -89,7 +93,6 @@ func init() {
 	StringVar(flags, &flagOpts.dataplaneConfig.Telemetry.Prometheus.ScrapePath, "telemetry-prom-scrape-path", "DP_TELEMETRY_PROM_SCRAPE_PATH", "The URL path where Envoy serves Prometheus metrics.")
 	IntVar(flags, &flagOpts.dataplaneConfig.Telemetry.Prometheus.MergePort, "telemetry-prom-merge-port", "DP_TELEMETRY_PROM_MERGE_PORT", "The port to serve merged Prometheus metrics.")
 
-	BoolVar(flags, &flagOpts.dataplaneConfig.Envoy.Enabled, "envoy-enabled", "DP_ENVOY_ENABLED", "Indicates whether the Envoy is run within dataplane.")
 	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.AdminBindAddr, "envoy-admin-bind-address", "DP_ENVOY_ADMIN_BIND_ADDRESS", "The address on which the Envoy admin server is available.")
 	IntVar(flags, &flagOpts.dataplaneConfig.Envoy.AdminBindPort, "envoy-admin-bind-port", "DP_ENVOY_ADMIN_BIND_PORT", "The port on which the Envoy admin server is available.")
 	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.ReadyBindAddr, "envoy-ready-bind-address", "DP_ENVOY_READY_BIND_ADDRESS", "The address on which Envoy's readiness probe is available.")
@@ -98,7 +101,6 @@ func init() {
 	IntVar(flags, &flagOpts.dataplaneConfig.Envoy.DrainTimeSeconds, "envoy-drain-time-seconds", "DP_ENVOY_DRAIN_TIME", "The time in seconds for which Envoy will drain connections.")
 	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.DrainStrategy, "envoy-drain-strategy", "DP_ENVOY_DRAIN_STRATEGY", "The behaviour of Envoy during the drain sequence. Determines whether all open connections should be encouraged to drain immediately or to increase the percentage gradually as the drain time elapses.")
 
-	BoolVar(flags, &flagOpts.dataplaneConfig.XDSServer.Enabled, "xds-enabled", "DP_XDS_ENABLED", "Indicates whether the Envoy xDS server is run within dataplane.")
 	StringVar(flags, &flagOpts.dataplaneConfig.XDSServer.BindAddr, "xds-bind-addr", "DP_XDS_BIND_ADDR", "The address on which the Envoy xDS server is available.")
 	IntVar(flags, &flagOpts.dataplaneConfig.XDSServer.BindPort, "xds-bind-port", "DP_XDS_BIND_PORT", "The port on which the Envoy xDS server is available.")
 
@@ -109,7 +111,6 @@ func init() {
 	StringVar(flags, &flagOpts.dataplaneConfig.Consul.TLS.ServerName, "tls-server-name", "DP_TLS_SERVER_NAME", "The hostname to expect in the server certificate's subject. This is required if -addresses is not a DNS name.")
 	BoolVar(flags, &flagOpts.dataplaneConfig.Consul.TLS.InsecureSkipVerify, "tls-insecure-skip-verify", "DP_TLS_INSECURE_SKIP_VERIFY", "Do not verify the server's certificate. Useful for testing, but not recommended for production.")
 
-	BoolVar(flags, &flagOpts.dataplaneConfig.DNSServer.Enabled, "consul-dns-enabled", "DP_CONSUL_DNS_ENABLED", "Indicates whether the consul DNS listener is run within dataplane.")
 	StringVar(flags, &flagOpts.dataplaneConfig.DNSServer.BindAddr, "consul-dns-bind-addr", "DP_CONSUL_DNS_BIND_ADDR", "The address that will be bound to the consul dns listener.")
 	IntVar(flags, &flagOpts.dataplaneConfig.DNSServer.BindPort, "consul-dns-bind-port", "DP_CONSUL_DNS_BIND_PORT", "The port the consul dns listener will listen on. By default -1 disables the dns listener.")
 

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -89,6 +89,7 @@ func init() {
 	StringVar(flags, &flagOpts.dataplaneConfig.Telemetry.Prometheus.ScrapePath, "telemetry-prom-scrape-path", "DP_TELEMETRY_PROM_SCRAPE_PATH", "The URL path where Envoy serves Prometheus metrics.")
 	IntVar(flags, &flagOpts.dataplaneConfig.Telemetry.Prometheus.MergePort, "telemetry-prom-merge-port", "DP_TELEMETRY_PROM_MERGE_PORT", "The port to serve merged Prometheus metrics.")
 
+	BoolVar(flags, &flagOpts.dataplaneConfig.Envoy.Enabled, "envoy-enabled", "DP_ENVOY_ENABLED", "Indicates whether the Envoy is run within dataplane.")
 	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.AdminBindAddr, "envoy-admin-bind-address", "DP_ENVOY_ADMIN_BIND_ADDRESS", "The address on which the Envoy admin server is available.")
 	IntVar(flags, &flagOpts.dataplaneConfig.Envoy.AdminBindPort, "envoy-admin-bind-port", "DP_ENVOY_ADMIN_BIND_PORT", "The port on which the Envoy admin server is available.")
 	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.ReadyBindAddr, "envoy-ready-bind-address", "DP_ENVOY_READY_BIND_ADDRESS", "The address on which Envoy's readiness probe is available.")
@@ -97,6 +98,7 @@ func init() {
 	IntVar(flags, &flagOpts.dataplaneConfig.Envoy.DrainTimeSeconds, "envoy-drain-time-seconds", "DP_ENVOY_DRAIN_TIME", "The time in seconds for which Envoy will drain connections.")
 	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.DrainStrategy, "envoy-drain-strategy", "DP_ENVOY_DRAIN_STRATEGY", "The behaviour of Envoy during the drain sequence. Determines whether all open connections should be encouraged to drain immediately or to increase the percentage gradually as the drain time elapses.")
 
+	BoolVar(flags, &flagOpts.dataplaneConfig.XDSServer.Enabled, "xds-enabled", "DP_XDS_ENABLED", "Indicates whether the Envoy xDS server is run within dataplane.")
 	StringVar(flags, &flagOpts.dataplaneConfig.XDSServer.BindAddr, "xds-bind-addr", "DP_XDS_BIND_ADDR", "The address on which the Envoy xDS server is available.")
 	IntVar(flags, &flagOpts.dataplaneConfig.XDSServer.BindPort, "xds-bind-port", "DP_XDS_BIND_PORT", "The port on which the Envoy xDS server is available.")
 
@@ -107,8 +109,9 @@ func init() {
 	StringVar(flags, &flagOpts.dataplaneConfig.Consul.TLS.ServerName, "tls-server-name", "DP_TLS_SERVER_NAME", "The hostname to expect in the server certificate's subject. This is required if -addresses is not a DNS name.")
 	BoolVar(flags, &flagOpts.dataplaneConfig.Consul.TLS.InsecureSkipVerify, "tls-insecure-skip-verify", "DP_TLS_INSECURE_SKIP_VERIFY", "Do not verify the server's certificate. Useful for testing, but not recommended for production.")
 
-	StringVar(flags, &flagOpts.dataplaneConfig.DNSServer.BindAddr, "consul-dns-bind-addr", "DP_CONSUL_DNS_BIND_ADDR", "The address that will be bound to the consul dns proxy.")
-	IntVar(flags, &flagOpts.dataplaneConfig.DNSServer.BindPort, "consul-dns-bind-port", "DP_CONSUL_DNS_BIND_PORT", "The port the consul dns proxy will listen on. By default -1 disables the dns proxy")
+	BoolVar(flags, &flagOpts.dataplaneConfig.DNSServer.Enabled, "consul-dns-enabled", "DP_CONSUL_DNS_ENABLED", "Indicates whether the consul DNS listener is run within dataplane.")
+	StringVar(flags, &flagOpts.dataplaneConfig.DNSServer.BindAddr, "consul-dns-bind-addr", "DP_CONSUL_DNS_BIND_ADDR", "The address that will be bound to the consul dns listener.")
+	IntVar(flags, &flagOpts.dataplaneConfig.DNSServer.BindPort, "consul-dns-bind-port", "DP_CONSUL_DNS_BIND_PORT", "The port the consul dns listener will listen on. By default -1 disables the dns listener.")
 
 	// Default is false because it will generally be configured appropriately by Helm
 	// configuration or pod annotation.

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -34,8 +34,6 @@ type ConsulConfig struct {
 
 // DNSServerConfig is the configuration for the transparent DNS proxy that will forward requests to consul
 type DNSServerConfig struct {
-	// Enabled configures whether DNS Server is enabled.
-	Enabled bool
 	// BindAddr is the address the DNS server will bind to. Default will be 127.0.0.1
 	BindAddr string
 	// Port is the port which the DNS server will bind to.
@@ -135,6 +133,18 @@ const (
 	// CredentialsTypeLogin indicates that credentials were provided to log in with
 	// an auth method.
 	CredentialsTypeLogin CredentialsType = "login"
+)
+
+// CredentialsType identifies the type of credentials provided.
+type ModeType string
+
+const (
+	// ModeTypeSidecar indicates that consul-dataplane is running in sidecar
+	// mode where DNS Server, xDS Server, and Envoy are all enabled.
+	ModeTypeSidecar ModeType = "sidecar"
+	// ModeTypeDNSProxy indicates that consul-dataplane is running in DNS Proxy
+	// mode where DNS Server is running but xDSServer and Envoy are disabled.
+	ModeTypeDNSProxy ModeType = "dns-proxy"
 )
 
 // StaticCredentialsConfig contains the static ACL token that will be used to
@@ -266,8 +276,6 @@ type PrometheusTelemetryConfig struct {
 
 // EnvoyConfig contains configuration for the Envoy process.
 type EnvoyConfig struct {
-	// Enabled configures whether Envoy is enabled.
-	Enabled bool
 	// AdminBindAddress is the address on which the Envoy admin server will be available.
 	AdminBindAddress string
 	// AdminBindPort is the port on which the Envoy admin server will be available.
@@ -311,8 +319,6 @@ type EnvoyConfig struct {
 
 // XDSServer contains the configuration of the xDS server.
 type XDSServer struct {
-	// Enabled configures whether xDS Server is enabled.
-	Enabled bool
 	// BindAddress is the address on which the Envoy xDS server will be available.
 	BindAddress string
 	// BindPort is the address on which the Envoy xDS port will be available.
@@ -322,6 +328,7 @@ type XDSServer struct {
 // Config is the configuration used by consul-dataplane, consolidated
 // from various sources - CLI flags, env vars, config file settings.
 type Config struct {
+	Mode      ModeType
 	DNSServer *DNSServerConfig
 	Consul    *ConsulConfig
 	Proxy     *ProxyConfig

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -329,10 +329,4 @@ type Config struct {
 	Telemetry *TelemetryConfig
 	Envoy     *EnvoyConfig
 	XDSServer *XDSServer
-	// DNSProxyMode indicates that consul-dataplane is not running as a sidecar
-	// and will:
-	// - disable xDS.
-	// - disable Envoy.
-	// - disable validation that DNS can only listen on loopback address.
-	DNSProxyMode *bool
 }

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -34,6 +34,8 @@ type ConsulConfig struct {
 
 // DNSServerConfig is the configuration for the transparent DNS proxy that will forward requests to consul
 type DNSServerConfig struct {
+	// Enabled configures whether DNS Server is enabled.
+	Enabled bool
 	// BindAddr is the address the DNS server will bind to. Default will be 127.0.0.1
 	BindAddr string
 	// Port is the port which the DNS server will bind to.
@@ -264,6 +266,8 @@ type PrometheusTelemetryConfig struct {
 
 // EnvoyConfig contains configuration for the Envoy process.
 type EnvoyConfig struct {
+	// Enabled configures whether Envoy is enabled.
+	Enabled bool
 	// AdminBindAddress is the address on which the Envoy admin server will be available.
 	AdminBindAddress string
 	// AdminBindPort is the port on which the Envoy admin server will be available.
@@ -307,6 +311,8 @@ type EnvoyConfig struct {
 
 // XDSServer contains the configuration of the xDS server.
 type XDSServer struct {
+	// Enabled configures whether xDS Server is enabled.
+	Enabled bool
 	// BindAddress is the address on which the Envoy xDS server will be available.
 	BindAddress string
 	// BindPort is the address on which the Envoy xDS port will be available.
@@ -323,4 +329,10 @@ type Config struct {
 	Telemetry *TelemetryConfig
 	Envoy     *EnvoyConfig
 	XDSServer *XDSServer
+	// DNSProxyMode indicates that consul-dataplane is not running as a sidecar
+	// and will:
+	// - disable xDS.
+	// - disable Envoy.
+	// - disable validation that DNS can only listen on loopback address.
+	DNSProxyMode *bool
 }

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -79,9 +79,9 @@ func validateConfig(cfg *Config) error {
 		return errors.New("consul addresses not specified")
 	case cfg.Consul.GRPCPort == 0:
 		return errors.New("consul server gRPC port not specified")
-	case cfg.Proxy == nil:
+	case cfg.Mode == ModeTypeSidecar && cfg.Proxy == nil:
 		return errors.New("proxy details not specified")
-	case cfg.Proxy.ProxyID == "":
+	case cfg.Mode == ModeTypeSidecar && cfg.Proxy.ProxyID == "":
 		return errors.New("proxy ID not specified")
 	case cfg.Mode == ModeTypeSidecar && cfg.Envoy == nil:
 		return errors.New("envoy settings not specified")

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -205,10 +205,8 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 	// return before configuring them.
 	if cdp.cfg.Mode == ModeTypeDNSProxy {
 		go func() {
-			select {
-			case <-ctx.Done():
-				doneCh <- nil
-			}
+			<-ctx.Done()
+			doneCh <- nil
 		}()
 		return <-doneCh
 	}

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -96,7 +96,7 @@ func validateConfig(cfg *Config) error {
 	case cfg.Mode == ModeTypeSidecar && !strings.HasPrefix(cfg.XDSServer.BindAddress, "unix://") && !net.ParseIP(cfg.XDSServer.BindAddress).IsLoopback():
 		return errors.New("non-local xDS bind address not allowed")
 	case cfg.Mode == ModeTypeSidecar && cfg.DNSServer.Port != -1 && !net.ParseIP(cfg.DNSServer.BindAddr).IsLoopback():
-		return errors.New("non-local DNS proxy bind address not allowed when running as sidecar")
+		return errors.New("non-local DNS proxy bind address not allowed when running as a sidecar")
 	}
 
 	creds := cfg.Consul.Credentials

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -83,19 +83,19 @@ func validateConfig(cfg *Config) error {
 		return errors.New("proxy details not specified")
 	case cfg.Proxy.ProxyID == "":
 		return errors.New("proxy ID not specified")
-	case cfg.Mode == ModeTypeSidecar && cfg.Envoy == nil:
+	case cfg.Envoy == nil:
 		return errors.New("envoy settings not specified")
-	case cfg.Mode == ModeTypeSidecar && cfg.Envoy.AdminBindAddress == "":
+	case cfg.Envoy.AdminBindAddress == "":
 		return errors.New("envoy admin bind address not specified")
-	case cfg.Mode == ModeTypeSidecar && cfg.Envoy.AdminBindPort == 0:
+	case cfg.Envoy.AdminBindPort == 0:
 		return errors.New("envoy admin bind port not specified")
 	case cfg.Logging == nil:
 		return errors.New("logging settings not specified")
-	case cfg.Mode == ModeTypeSidecar && cfg.XDSServer.BindAddress == "":
+	case cfg.XDSServer.BindAddress == "":
 		return errors.New("envoy xDS bind address not specified")
-	case cfg.Mode == ModeTypeSidecar && !strings.HasPrefix(cfg.XDSServer.BindAddress, "unix://") && !net.ParseIP(cfg.XDSServer.BindAddress).IsLoopback():
+	case !strings.HasPrefix(cfg.XDSServer.BindAddress, "unix://") && !net.ParseIP(cfg.XDSServer.BindAddress).IsLoopback():
 		return errors.New("non-local xDS bind address not allowed")
-	case cfg.Mode == ModeTypeSidecar && cfg.DNSServer.Port != -1 && !net.ParseIP(cfg.DNSServer.BindAddr).IsLoopback():
+	case cfg.DNSServer.Port != -1 && !net.ParseIP(cfg.DNSServer.BindAddr).IsLoopback():
 		return errors.New("non-local DNS proxy bind address not allowed when running as sidecar")
 	}
 
@@ -179,6 +179,12 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 	cdp.aclToken = state.Token
 	cdp.dpServiceClient = pbdataplane.NewDataplaneServiceClient(state.GRPCConn)
 
+	err = cdp.setupXDSServer()
+	if err != nil {
+		return err
+	}
+	go cdp.startXDSServer(ctx)
+
 	bootstrapCfg, cfg, err := cdp.bootstrapConfig(ctx)
 	if err != nil {
 		cdp.logger.Error("failed to get bootstrap config", "error", err)
@@ -191,27 +197,6 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		cdp.logger.Error("failed to start the dns proxy", "error", err)
 		return err
 	}
-
-	doneCh := make(chan error)
-
-	//// if running as DNS PRoxy, xDS Server and Envoy are disabled, so
-	//// return before configuring them.
-	//if cdp.cfg.Mode == ModeTypeDNSProxy {
-	//	go func() {
-	//		select {
-	//		case <-ctx.Done():
-	//			doneCh <- nil
-	//		}
-	//	}()
-	//	return <-doneCh
-	//}
-
-	// start up xDS server and Envoy if configured as a sidecar
-	err = cdp.setupXDSServer()
-	if err != nil {
-		return err
-	}
-	go cdp.startXDSServer(ctx)
 
 	proxy, err := envoy.NewProxy(cdp.envoyProxyConfig(cfg))
 	if err != nil {
@@ -235,6 +220,7 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		return err
 	}
 
+	doneCh := make(chan error)
 	go func() {
 		select {
 		case <-ctx.Done():

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -12,6 +12,7 @@ import (
 
 func validConfig() *Config {
 	return &Config{
+		Mode: ModeTypeSidecar,
 		Consul: &ConsulConfig{
 			Addresses: "consul.servers.dns.com",
 			GRPCPort:  1234,
@@ -160,7 +161,7 @@ func TestNewConsulDPError(t *testing.T) {
 				c.DNSServer.BindAddr = "1.2.3.4"
 				c.DNSServer.Port = 1
 			},
-			expectErr: "non-local DNS proxy bind address not allowed",
+			expectErr: "non-local DNS proxy bind address not allowed when running as a sidecar",
 		},
 		{
 			name: "no bearer token or path given",


### PR DESCRIPTION
This PR adds a to level `mode` flag which has the follow characteristics:
- Options available are `sidecar` and `dns-proxy`.  defaults to `sidecar`
- When set to `sidecar`:
  - DNS Server, xDS Server, and Envoy are enabled
  - it validates `-consul-dns-bind-addr` and equivalent environment variable must be set to the loopback address
- When set to `dns-proxy`
  -  only DNS Server is enabled.  xDS Server and Envoy are disabled.
  - `consul-dns-bind-addr` and equivalent environment variable can be set to other values besides the loopback address.