### PR TITLE
NET-10480 - fix setting namespace and partition setting in dns-proxy mode

### DIFF
--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -26,7 +26,7 @@ const (
 	defaultAdminAccessLogsPath = os.DevNull
 )
 
-// bootstrapConfig generates the Envoy bootstrap config in JSON format.
+// getBootstrapParams makes a call using the service client to get the bootstrap params for eventually getting the Envoy bootstrap config.
 func (cdp *ConsulDataplane) getBootstrapParams(ctx context.Context) (*pbdataplane.GetEnvoyBootstrapParamsResponse, error) {
 	svc := cdp.cfg.Proxy
 

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -27,9 +27,8 @@ const (
 )
 
 // bootstrapConfig generates the Envoy bootstrap config in JSON format.
-func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.BootstrapConfig, []byte, error) {
+func (cdp *ConsulDataplane) getBootstrapParams(ctx context.Context) (*pbdataplane.GetEnvoyBootstrapParamsResponse, error) {
 	svc := cdp.cfg.Proxy
-	envoy := cdp.cfg.Envoy
 
 	req := &pbdataplane.GetEnvoyBootstrapParamsRequest{
 		ServiceId: svc.ProxyID,
@@ -50,16 +49,17 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 
 	rsp, err := cdp.dpServiceClient.GetEnvoyBootstrapParams(ctx, req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get envoy bootstrap params: %w", err)
+		return nil, fmt.Errorf("failed to get envoy bootstrap params: %w", err)
 	}
 
-	// store the final resolved service for others to use.
-	cdp.resolvedProxyConfig = ProxyConfig{
-		NodeName:  rsp.NodeName,
-		ProxyID:   cdp.cfg.Proxy.ProxyID,
-		Namespace: rsp.Namespace,
-		Partition: rsp.Partition,
-	}
+	return rsp, nil
+}
+
+// bootstrapConfig generates the Envoy bootstrap config in JSON format.
+func (cdp *ConsulDataplane) bootstrapConfig(
+	bootstrapParams *pbdataplane.GetEnvoyBootstrapParamsResponse) (*bootstrap.BootstrapConfig, []byte, error) {
+	svc := cdp.cfg.Proxy
+	envoy := cdp.cfg.Envoy
 
 	prom := cdp.cfg.Telemetry.Prometheus
 	args := &bootstrap.BootstrapTplArgs{
@@ -68,26 +68,26 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 			AgentPort:    strconv.Itoa(cdp.cfg.XDSServer.BindPort),
 			AgentTLS:     false,
 		},
-		ProxyCluster:          rsp.Service,
+		ProxyCluster:          bootstrapParams.Service,
 		ProxyID:               svc.ProxyID,
-		NodeName:              rsp.NodeName,
-		ProxySourceService:    rsp.Service,
-		AdminAccessLogConfig:  rsp.AccessLogs,
+		NodeName:              bootstrapParams.NodeName,
+		ProxySourceService:    bootstrapParams.Service,
+		AdminAccessLogConfig:  bootstrapParams.AccessLogs,
 		AdminAccessLogPath:    defaultAdminAccessLogsPath,
 		AdminBindAddress:      envoy.AdminBindAddress,
 		AdminBindPort:         strconv.Itoa(envoy.AdminBindPort),
 		LocalAgentClusterName: localClusterName,
-		Namespace:             rsp.Namespace,
-		Partition:             rsp.Partition,
-		Datacenter:            rsp.Datacenter,
+		Namespace:             bootstrapParams.Namespace,
+		Partition:             bootstrapParams.Partition,
+		Datacenter:            bootstrapParams.Datacenter,
 		PrometheusCertFile:    prom.CertFile,
 		PrometheusKeyFile:     prom.KeyFile,
 		PrometheusScrapePath:  prom.ScrapePath,
 	}
 
-	if rsp.Identity != "" {
-		args.ProxyCluster = rsp.Identity
-		args.ProxySourceService = rsp.Identity
+	if bootstrapParams.Identity != "" {
+		args.ProxyCluster = bootstrapParams.Identity
+		args.ProxySourceService = bootstrapParams.Identity
 	}
 
 	if cdp.xdsServer.listenerNetwork == "unix" {
@@ -116,7 +116,7 @@ func (cdp *ConsulDataplane) bootstrapConfig(ctx context.Context) (*bootstrap.Boo
 	}
 
 	if cdp.cfg.Telemetry.UseCentralConfig {
-		if err := mapstructure.WeakDecode(rsp.Config.AsMap(), &bootstrapConfig); err != nil {
+		if err := mapstructure.WeakDecode(bootstrapParams.Config.AsMap(), &bootstrapConfig); err != nil {
 			return nil, nil, fmt.Errorf("failed parsing Proxy.Config: %w", err)
 		}
 

--- a/pkg/consuldp/bootstrap_test.go
+++ b/pkg/consuldp/bootstrap_test.go
@@ -300,14 +300,23 @@ func TestBootstrapConfig(t *testing.T) {
 				dp.xdsServer = &xdsServer{listenerAddress: fmt.Sprintf("127.0.0.1:%d", xdsBindPort)}
 			}
 
-			_, bsCfg, err := dp.bootstrapConfig(ctx)
+			params, err := dp.getBootstrapParams(ctx)
+			require.NoError(t, err)
+
+			_, bsCfg, err := dp.bootstrapConfig(params)
 			require.NoError(t, err)
 
 			golden(t, bsCfg)
 			validateBootstrapConfig(t, bsCfg)
 
 			if tc.resolvedProxyConfig != nil {
-				require.Equal(t, *tc.resolvedProxyConfig, dp.resolvedProxyConfig)
+				proxyCfg := ProxyConfig{
+					NodeName:  params.NodeName,
+					ProxyID:   dp.cfg.Proxy.ProxyID,
+					Namespace: params.Namespace,
+					Partition: params.Partition,
+				}
+				require.Equal(t, *tc.resolvedProxyConfig, proxyCfg)
 			}
 		})
 	}

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -311,6 +311,14 @@ func TestNewConsulDPError(t *testing.T) {
 			},
 			expectErr: "bearer token (or path to a file containing a bearer token) is required for login",
 		},
+		{
+			name: "dns-proxy mode - namespace set to non empty or default value",
+			mode: ModeTypeDNSProxy,
+			modFn: func(c *Config) {
+				c.Proxy.Namespace = "test"
+			},
+			expectErr: "namespace must be empty or set to 'default' when running in dns-proxy mode",
+		},
 	}
 
 	testCases = append(testCases, dnsProxyTestCases...)

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -106,6 +106,8 @@ func (d *DNSServer) Start(ctx context.Context) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
+	d.logger.Debug("starting DNS proxy", "partition", d.partition, "namespace", d.namespace)
+
 	if d.running {
 		return ErrServerRunning
 	}
@@ -215,6 +217,8 @@ func (d *DNSServer) queryConsulAndRespondUDP(buf []byte, addr net.Addr) {
 		"x-consul-token", d.token,
 	)
 
+	logger.Debug("querying through udp", "partition", d.partition, "namespace", d.namespace)
+
 	resp, err := d.client.Query(ctx, req)
 	if err != nil {
 		logger.Error("error resolving consul request", "error", err)
@@ -300,6 +304,8 @@ func (d *DNSServer) proxyTCPAcceptedConn(ctx context.Context, conn net.Conn, cli
 			"x-consul-namespace", d.namespace,
 			"x-consul-token", d.token,
 		)
+
+		logger.Debug("querying through tcp", "partition", d.partition, "namespace", d.namespace)
 
 		resp, err := client.Query(ctx, req)
 		if err != nil {


### PR DESCRIPTION
This fixes how namespace and partition get set when in dns-proxy mode.  The prior attempt at this moved starting the DNS above starting envoy.  What was not clear was that starting envoy set `resolvedProxyConfig` in state so it was not set when DNS started and dns-proxy always started with the default namespace and partition.  In the process, i also got rid of using state to pass parameters and just used the function signature to have the appropriate parameters.
