### PR TITLE
fix linter error

### DIFF
--- a/pkg/consuldp/xds.go
+++ b/pkg/consuldp/xds.go
@@ -28,7 +28,7 @@ const (
 func (cdp *ConsulDataplane) director(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
 	// check to ensure other unknown/unregistered RPCs are not proxied to the target consul server.
 	if !strings.Contains(fullMethodName, envoyADSMethodName) {
-		return ctx, nil, status.Errorf(codes.Unimplemented, fmt.Sprintf("Unknown method %s", fullMethodName))
+		return ctx, nil, status.Errorf(codes.Unimplemented, "Unknown method %s", fullMethodName)
 	}
 
 	var mdCopy metadata.MD


### PR DESCRIPTION
This trigger a linter error with golangci-lint version 1.60.3.

I will need to backport this for 1.5.2 release. Added in https://github.com/hashicorp/consul-dataplane/pull/600