### PR TITLE
ci: update the security-scanner gha token

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
       - release/**
+    paths-ignore:
+      - '_doc/**'
+      - '.changelog/**'
 
 # cancel existing runs of the same workflow on the same ref
 concurrency:
@@ -16,13 +19,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  conditional-skip:
-    uses: ./.github/workflows/reusable-conditional-skip.yml
 
   get-go-version:
     # Cascades down to test jobs
-    needs: [conditional-skip]
-    if: needs.conditional-skip.outputs.skip-ci != 'true'
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   scan:
@@ -46,7 +45,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: hashicorp/security-scanner
-          token: ${{ secrets.HASHIBOT_PRODSEC_GITHUB_TOKEN }}
+          token: ${{ secrets.PRODSEC_SCANNER_READ_ONLY }}
           path: security-scanner
           ref: main
 


### PR DESCRIPTION
### Description

Using the org level secret instead of the repository one and removing conditional check to use `paths-ignore`.

### Testing & Reproduction steps

If the security scan passes, we are good.

### Links

<!--

Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

-->

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] appropriate backport labels added
* [ ] not a security concern
