### PR TITLE
[Experimental] Include both privileged and non-privileged binaries in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,16 @@ COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
 
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
 COPY --from=go-discover /go/bin/discover /usr/local/bin/
-COPY --from=setcap-envoy-binary /usr/local/bin/envoy /usr/local/bin/
-COPY --from=setcap-envoy-binary /usr/local/bin/$BIN_NAME /usr/local/bin/
 COPY LICENSE /licenses/copyright.txt
+
+# Since we can't know at build time if a runtime will attempt to bind to privileged ports,
+# include a version that supports privileged ports and a version that doesn't.
+# Determine at runtime which to use. This prevents a blanket requirement for NET_BIND_SERVICE
+# in use cases which actually don't require it.
+COPY --from=envoy-binary /usr/local/bin/envoy /usr/local/bin/
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
+COPY --from=setcap-envoy-binary /usr/local/bin/envoy /usr/local/bin/privileged-envoy
+COPY --from=setcap-envoy-binary /usr/local/bin/$BIN_NAME /usr/local/bin/privileged-$BIN_NAME
 
 USER 100
 
@@ -115,9 +122,16 @@ COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
 
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
 COPY --from=go-discover /go/bin/discover /usr/local/bin/
-COPY --from=setcap-envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/
-COPY --from=setcap-envoy-fips-binary /usr/local/bin/$BIN_NAME /usr/local/bin/
 COPY LICENSE /licenses/copyright.txt
+
+# Since we can't know at build time if a runtime will attempt to bind to privileged ports,
+# include a version that supports privileged ports and a version that doesn't.
+# Determine at runtime which to use. This prevents a blanket requirement for NET_BIND_SERVICE
+# in use cases which actually don't require it.
+COPY --from=envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
+COPY --from=setcap-envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/privileged-envoy
+COPY --from=setcap-envoy-fips-binary /usr/local/bin/$BIN_NAME /usr/local/bin/privileged-$BIN_NAME
 
 USER 100
 
@@ -158,9 +172,16 @@ RUN groupadd --gid 1000 $PRODUCT_NAME && \
 
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
 COPY --from=go-discover /go/bin/discover /usr/local/bin/
-COPY --from=setcap-envoy-binary /usr/local/bin/envoy /usr/local/bin/
-COPY --from=setcap-envoy-binary /usr/local/bin/$BIN_NAME /usr/local/bin/
 COPY LICENSE /licenses/copyright.txt
+
+# Since we can't know at build time if a runtime will attempt to bind to privileged ports,
+# include a version that supports privileged ports and a version that doesn't.
+# Determine at runtime which to use. This prevents a blanket requirement for NET_BIND_SERVICE
+# in use cases which actually don't require it.
+COPY --from=envoy-binary /usr/local/bin/envoy /usr/local/bin/
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
+COPY --from=setcap-envoy-binary /usr/local/bin/envoy /usr/local/bin/privileged-envoy
+COPY --from=setcap-envoy-binary /usr/local/bin/$BIN_NAME /usr/local/bin/privileged-$BIN_NAME
 
 USER 100
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
@@ -200,9 +221,16 @@ RUN groupadd --gid 1000 $PRODUCT_NAME && \
 
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
 COPY --from=go-discover /go/bin/discover /usr/local/bin/
-COPY --from=setcap-envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/
-COPY --from=setcap-envoy-fips-binary /usr/local/bin/$BIN_NAME /usr/local/bin/
 COPY LICENSE /licenses/copyright.txt
+
+# Since we can't know at build time if a runtime will attempt to bind to privileged ports,
+# include a version that supports privileged ports and a version that doesn't.
+# Determine at runtime which to use. This prevents a blanket requirement for NET_BIND_SERVICE
+# in use cases which actually don't require it.
+COPY --from=envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /usr/local/bin/
+COPY --from=setcap-envoy-fips-binary /usr/local/bin/envoy /usr/local/bin/privileged-envoy
+COPY --from=setcap-envoy-fips-binary /usr/local/bin/$BIN_NAME /usr/local/bin/privileged-$BIN_NAME
 
 USER 100
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -136,6 +136,7 @@ type EnvoyFlags struct {
 	Concurrency      *int    `json:"concurrency,omitempty"`
 	DrainTimeSeconds *int    `json:"drainTimeSeconds,omitempty"`
 	DrainStrategy    *string `json:"drainStrategy,omitempty"`
+	ExecutablePath   *string `json:"executablePath,omitempty"`
 
 	ShutdownDrainListenersEnabled *bool   `json:"shutdownDrainListenersEnabled,omitempty"`
 	ShutdownGracePeriodSeconds    *int    `json:"shutdownGracePeriodSeconds,omitempty"`
@@ -182,12 +183,7 @@ func (f *FlagOpts) buildDataplaneConfig(extraArgs []string) (*consuldp.Config, e
 		return nil, err
 	}
 
-	consuldpRuntimeConfig, err := constructRuntimeConfig(consulDPDefaultFlags, extraArgs)
-	if err != nil {
-		return nil, err
-	}
-
-	return consuldpRuntimeConfig, nil
+	return constructRuntimeConfig(consulDPDefaultFlags, extraArgs)
 }
 
 // Constructs a config based on the values present in the config json file
@@ -328,6 +324,7 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 		Envoy: &consuldp.EnvoyConfig{
 			AdminBindAddress:              stringVal(cfg.Envoy.AdminBindAddr),
 			AdminBindPort:                 intVal(cfg.Envoy.AdminBindPort),
+			ExecutablePath:                stringVal(cfg.Envoy.ExecutablePath),
 			ReadyBindAddress:              stringVal(cfg.Envoy.ReadyBindAddr),
 			ReadyBindPort:                 intVal(cfg.Envoy.ReadyBindPort),
 			EnvoyConcurrency:              intVal(cfg.Envoy.Concurrency),

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -100,6 +100,7 @@ func init() {
 	IntVar(flags, &flagOpts.dataplaneConfig.Envoy.Concurrency, "envoy-concurrency", "DP_ENVOY_CONCURRENCY", "The number of worker threads that Envoy uses.")
 	IntVar(flags, &flagOpts.dataplaneConfig.Envoy.DrainTimeSeconds, "envoy-drain-time-seconds", "DP_ENVOY_DRAIN_TIME", "The time in seconds for which Envoy will drain connections.")
 	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.DrainStrategy, "envoy-drain-strategy", "DP_ENVOY_DRAIN_STRATEGY", "The behaviour of Envoy during the drain sequence. Determines whether all open connections should be encouraged to drain immediately or to increase the percentage gradually as the drain time elapses.")
+	StringVar(flags, &flagOpts.dataplaneConfig.Envoy.ExecutablePath, "envoy-executable-path", "DP_ENVOY_EXECUTABLE_PATH", "Path to the Envoy executable to run. Defaults to the ")
 
 	StringVar(flags, &flagOpts.dataplaneConfig.XDSServer.BindAddr, "xds-bind-addr", "DP_XDS_BIND_ADDR", "The address on which the Envoy xDS server is available.")
 	IntVar(flags, &flagOpts.dataplaneConfig.XDSServer.BindPort, "xds-bind-port", "DP_XDS_BIND_PORT", "The port on which the Envoy xDS server is available.")

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -276,6 +276,7 @@ type PrometheusTelemetryConfig struct {
 
 // EnvoyConfig contains configuration for the Envoy process.
 type EnvoyConfig struct {
+	ExecutablePath string
 	// AdminBindAddress is the address on which the Envoy admin server will be available.
 	AdminBindAddress string
 	// AdminBindPort is the port on which the Envoy admin server will be available.

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -227,6 +227,7 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 	cdp.logger.Debug("generated envoy bootstrap config", "config", string(cfg))
 
 	cdp.logger.Info("configuring envoy and xDS")
+
 	proxy, err := envoy.NewProxy(cdp.envoyProxyConfig(cfg))
 	if err != nil {
 		cdp.logger.Error("failed to create new proxy", "error", err)
@@ -341,6 +342,7 @@ func (cdp *ConsulDataplane) envoyProxyConfig(cfg []byte) envoy.ProxyConfig {
 		Logger:          cdp.logger,
 		LogJSON:         cdp.cfg.Logging.LogJSON,
 		BootstrapConfig: cfg,
+		ExecutablePath:  cdp.cfg.Envoy.ExecutablePath,
 		ExtraArgs:       extraArgs,
 	}
 }


### PR DESCRIPTION
Currently, the `NET_BIND_SERVICE` capability is added to the dataplane (and Envoy) entrypoints since we cannot know at build time whether a non-root user at runtime will attempt to bind to a privileged port. The reason this is the default behavior was to avoid a breaking change in ingress gateways, which had previously supported binding to privileged ports; however, there are still many use cases where it's preferable to avoid this capability when it isn't needed.

This change introduces a second set of entrypoints to the container that _do not_ have the `NET_BIND_SERVICE` capability. In this way, we can support both use cases:
- Ingress gateways, which have historically supported binding to privileged ports
- All other use cases (sidecar and API, mesh, terminating gateways) which _do not_ need to support binding to privileged ports

The container will default to the non-privileged entrypoint, and ingress gateway deployments that do want to support binding to privileged ports will need to override the entrypoint to `privileged-consul-dataplane` and provide a path to `privileged-envoy`. This way, no deployment needs the `NET_BIND_SERVICE` capability unless they are overriding the entrypoint in order to support binding to privileged ports.

See https://github.com/hashicorp/consul-k8s/pull/4394 for an example of how this works in consul-k8s.

> [!WARNING]
> We still need to determine the impact – if any – of a change like this for VM and Nomad deployments of consul-dataplane