### PR TITLE
Manual Backport of CVE: update tj-actions/changed-files to fix GHSA-mrrh-fwg8-r2c3 into release/1.5.x

### DIFF
--- a/.changelog/738.txt
+++ b/.changelog/738.txt
@@ -1,0 +1,3 @@
+```release-note:security
+CVE: update tj-actions/changed-files to fix CVE-2025-30066
+```

--- a/.github/workflows/reusable-conditional-skip.yml
+++ b/.github/workflows/reusable-conditional-skip.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - name: Check for skippable file changes
         id: changed-files
-        uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275 # v45.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           # This is a multi-line YAML string with one match pattern per line.
           # Do not use quotes around values, as it's not supported.


### PR DESCRIPTION
## Backport

This PR is to backport following PRs from consul CE:
- https://github.com/hashicorp/consul-dataplane/pull/738
<details>
<summary> Overview of commits </summary>
- 1140ff4c00352b51444c939f4f578a2c2a06598e
- a822513f1ebb041aa98a8b2db826c5b4fa0a30c6
</details>


------------------------------------------------------------------

* CVE: update tj-actions/changed-files to fix GHSA-mrrh-fwg8-r2c3

* add: changelog