### PR TITLE
build: bump the version of debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.33.0 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.33.3 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bookworm-slim AS setcap-envoy-binary


### PR DESCRIPTION
Bumping the Debian image used to the latest one ([ref](https://wiki.debian.org/LTS)) and Envoy to v1.33.3.