### PR TITLE
update: ubuntu runner to 22.04 in build-linux workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     needs:
       - get-go-version
       - get-product-version
-    runs-on: ubuntu-20.04 # the GLIBC is too high on 22.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
- Update the github runner ubuntu version to 22.04 since 20.04 is deprecated.