### PR TITLE
Post release/1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.8 (May 22, 2025)
+
+SECURITY:
+
+* CVE: update tj-actions/changed-files to fix CVE-2025-30066 [[GH-738](https://github.com/hashicorp/consul-dataplane/pull/738)]
+
 ## 1.5.7 (April 24, 2025)
 
 * Upgraded `x/net` to 0.38.0. This resolves [GO-2025-3595](https://pkg.go.dev/vuln/GO-2025-3595)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,7 +17,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.5.8"
+	Version = "1.5.9"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Post release changes for release 1.5.8

- update: changelog from release 1.5.8
- update: version to 1.5.9 in version.go