### PR TITLE
update: runner version to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     needs:
       - get-go-version
       - get-product-version
-    runs-on: ubuntu-20.04 # the GLIBC is too high on 22.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
- update: deprecated github runner 20.04 to 22.04