### PR TITLE
update: envoy version to 1.34.4 in Dockerfile (#808)

### DIFF
--- a/.changelog/808.txt
+++ b/.changelog/808.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Update Envoy version to 1.34.4
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-FROM envoyproxy/envoy-distroless:v1.34.3 as envoy-binary
+FROM envoyproxy/envoy-distroless:v1.34.4 as envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bookworm-slim AS setcap-envoy-binary


### PR DESCRIPTION
* update: envoy version to 1.35.0 in Dockerfile

* add: changelog

* fix: use 1.33.0 for envoy-fips

* fix: set envoy-distroless to v1.34.4

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
