### PR TITLE
chore: udpated backport workflow to pick merge commit

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -16,7 +16,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.5
+    container: hashicorpdev/backport-assistant:v0.5.8
     steps:
       - name: Run Backport Assistant for release branches
         run: |
@@ -25,3 +25,5 @@ jobs:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          BACKPORT_MERGE_COMMIT: true
+          ENABLE_VERSION_MANIFESTS: true


### PR DESCRIPTION
updated the backport assistant version and changed it to use merge commit instead of cherry picking each commit from the PR