### PR TITLE
fix: remove ENABLE_VERSION_MANIFESTS in backport-assistant

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -26,4 +26,3 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           BACKPORT_MERGE_COMMIT: true
-          ENABLE_VERSION_MANIFESTS: true


### PR DESCRIPTION
- remove unused ENABLE_VERSION_MANIFESTS flag in backport-assistant workflow. We don't use version manifest in consul-dataplane. This is causing the backport-assistant to fail due to the absence of versions.hcl file.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
