### PR TITLE
Fix Build & Upload workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Build ubuntu-focal-builder image
         if: ${{ matrix.goos != 'windows' && matrix.fips == '+fips1402' }}
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
+        uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64 # we only ever build amd64 images because we always run on amd64 runners and cross-compile inside the container if needed
           context: .github/containers/ubuntu/


### PR DESCRIPTION
## PCI review checklist

For release/1.7.9 branch "upload-dev-artifacts" workflow is failing with following error 

`Error: -22T05:09:24.605Z [ERROR] bob: Failed to download workflow artifact: org=hashicorp repo=consul-dataplane error="extract: failed to unpack: failed to create safe file: failed to create file: open .bob/artifacts/oci-layout: permission denied"`

The current fix is to try and fix it as per the [thread](https://ibm-hashicorp.slack.com/archives/C09KTBT7NGK/p1766214486041129?thread_ts=1766164844.293279&cid=C09KTBT7NGK)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
