### PR TITLE
fix: add skip_exit to drain_listeners to prevent premature pod termination - 2

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -179,7 +179,7 @@ func (p *Proxy) Run(ctx context.Context) error {
 // Note: the caller is responsible for ensuring Drain is not called concurrently
 // with Run, as this is thread-unsafe.
 func (p *Proxy) Drain() error {
-	envoyDrainListenersUrl := fmt.Sprintf("http://%s/drain_listeners?inboundonly&graceful", net.JoinHostPort(p.cfg.AdminAddr, strconv.Itoa(p.cfg.AdminBindPort)))
+	envoyDrainListenersUrl := fmt.Sprintf("http://%s/drain_listeners?inboundonly&graceful&skip_exit", net.JoinHostPort(p.cfg.AdminAddr, strconv.Itoa(p.cfg.AdminBindPort)))
 	switch p.getState() {
 	case stateExited:
 		// Nothing to do!


### PR DESCRIPTION
### Description
When upgrading Envoy from 1.35 to 1.37, pods were being terminated early
during graceful shutdown. The POST /drain_listeners?graceful endpoint causes
Envoy to automatically exit after the drain period (--drain-time-s), which
raced against consul-dataplane's own lifecycle sequencing:

Drain() → wait shutdownGracePeriodSeconds → Quit() → Kill()

Adding &skip_exit decouples the drain phase from the exit decision, ensuring
Envoy stays alive until consul-dataplane explicitly calls Quit() via
/quitquitquit, preserving the intended shutdown lifecycle control.