### PR TITLE
fix: use net.JoinHostPort for remaining Envoy admin URLs

### DIFF
--- a/.changelog/1066.txt
+++ b/.changelog/1066.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+- envoy: use safe host:port construction for remaining admin API URLs to avoid malformed admin endpoint URLs with IPv6 addresses

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -287,7 +287,10 @@ func (p *Proxy) DumpConfig() error {
 }
 
 func (p *Proxy) dumpConfig() error {
-	envoyConfigDumpUrl := fmt.Sprintf("http://%s:%v/config_dump?include_eds", p.cfg.AdminAddr, p.cfg.AdminBindPort)
+	envoyConfigDumpUrl := fmt.Sprintf(
+		"http://%s/config_dump?include_eds",
+		net.JoinHostPort(p.cfg.AdminAddr, strconv.Itoa(p.cfg.AdminBindPort)),
+	)
 
 	rsp, err := p.client.Get(envoyConfigDumpUrl)
 	if err != nil {
@@ -398,7 +401,10 @@ func (p *Proxy) Ready() (bool, error) {
 		return false, nil
 	case stateRunning, stateInitial:
 		// Query ready endpoint to check if proxy is Ready
-		envoyReadyURL := fmt.Sprintf("http://%s:%v/ready", p.cfg.AdminAddr, p.cfg.AdminBindPort)
+		envoyReadyURL := fmt.Sprintf(
+			"http://%s/ready",
+			net.JoinHostPort(p.cfg.AdminAddr, strconv.Itoa(p.cfg.AdminBindPort)),
+		)
 		rsp, err := p.client.Get(envoyReadyURL)
 		if err != nil {
 			p.cfg.Logger.Error("envoy: admin endpoint not available", "error", err)


### PR DESCRIPTION
### Description

Follow-up to [#1064](https://github.com/hashicorp/consul-dataplane/pull/1064).

This updates the remaining Envoy admin URLs in `pkg/envoy/proxy.go` to use `net.JoinHostPort` instead of manually formatting `host:port` pairs.

The previous `fmt.Sprintf("http://%s:%v/...")` pattern is not safe for all admin bind addresses, especially IPv6 addresses. `Drain()` and `Quit()` were already updated to use `net.JoinHostPort`; this change applies the same fix to:
- `DumpConfig()` via `/config_dump?include_eds`
- `Ready()` via `/ready`

This keeps Envoy admin endpoint construction consistent across the proxy manager and avoids malformed URLs when the admin address is not a simple IPv4/hostname value.

### Testing

- Ran `pkg/envoy/proxy_test.go`