### PR TITLE
ci: add Go test coverage reporting

### DIFF
--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -27,7 +27,24 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - run: go test ./... -p 1 # disable parallelism to avoid port conflicts from default metrics and lifecycle server configuration
+      - run: go test ./... -p 1 -coverprofile=coverage.txt -covermode=set # disable parallelism to avoid port conflicts from default metrics and lifecycle server configuration
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        if: always()
+        with:
+          name: unit-tests-coverage
+          path: coverage.txt
+          if-no-files-found: ignore
+
+  coverage-report:
+    needs:
+      - get-go-version
+      - unit-tests
+    uses: ./.github/workflows/reusable-coverage-report.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
 
   integration-tests:
     name: integration-tests

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -127,14 +127,39 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PCT=$(echo "$TOTAL" | tr -d '%')
-          if awk "BEGIN {exit !($PCT >= 75)}"; then COLOR="brightgreen"
-          elif awk "BEGIN {exit !($PCT >= 60)}"; then COLOR="green"
-          elif awk "BEGIN {exit !($PCT >= 40)}"; then COLOR="yellow"
-          else COLOR="red"
+          if awk "BEGIN {exit !($PCT >= 75)}"; then COLOR="#4c1"
+          elif awk "BEGIN {exit !($PCT >= 60)}"; then COLOR="#97CA00"
+          elif awk "BEGIN {exit !($PCT >= 40)}"; then COLOR="#dfb317"
+          else COLOR="#e05d44"
           fi
 
-          printf '{"schemaVersion":1,"label":"coverage","message":"%s","color":"%s"}\n' \
-            "$TOTAL" "$COLOR" > /tmp/coverage-badge.json
+          # Compute dynamic text widths: label "coverage" = 62px, value width ~7px/char
+          LABEL="coverage"
+          LABEL_W=62
+          VAL_LEN=${#TOTAL}
+          VAL_W=$(( VAL_LEN * 7 + 10 ))
+          TOTAL_W=$(( LABEL_W + VAL_W ))
+          LABEL_MID=$(( LABEL_W / 2 + 1 ))
+          VAL_MID=$(( LABEL_W + VAL_W / 2 ))
+
+          cat > /tmp/coverage.svg <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="${TOTAL_W}" height="20">
+            <linearGradient id="s" x2="0" y2="100%">
+              <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+              <stop offset="1" stop-opacity=".1"/>
+            </linearGradient>
+            <rect rx="3" width="${TOTAL_W}" height="20" fill="#555"/>
+            <rect rx="3" x="${LABEL_W}" width="${VAL_W}" height="20" fill="${COLOR}"/>
+            <rect x="${LABEL_W}" width="4" height="20" fill="${COLOR}"/>
+            <rect rx="3" width="${TOTAL_W}" height="20" fill="url(#s)"/>
+            <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+              <text x="${LABEL_MID}" y="15" fill="#010101" fill-opacity=".3">${LABEL}</text>
+              <text x="${LABEL_MID}" y="14">${LABEL}</text>
+              <text x="${VAL_MID}" y="15" fill="#010101" fill-opacity=".3">${TOTAL}</text>
+              <text x="${VAL_MID}" y="14">${TOTAL}</text>
+            </g>
+          </svg>
+          SVGEOF
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -150,8 +175,8 @@ jobs:
             git -C /tmp/badges-wt rm -rf . --quiet 2>/dev/null || true
           fi
 
-          cp /tmp/coverage-badge.json /tmp/badges-wt/coverage.json
-          git -C /tmp/badges-wt add coverage.json
+          cp /tmp/coverage.svg /tmp/badges-wt/coverage.svg
+          git -C /tmp/badges-wt add coverage.svg
           if git -C /tmp/badges-wt diff --staged --quiet; then
             echo "Badge unchanged, skipping commit"
           else

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -1,0 +1,153 @@
+name: reusable-coverage-report
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Download coverage profiles
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: '*-coverage'
+          path: coverage-artifacts
+
+      - name: Compute coverage
+        id: coverage
+        run: |
+          PROFILES=$(find coverage-artifacts -name 'coverage.txt' 2>/dev/null | sort)
+          COUNT=$(echo "$PROFILES" | grep -c . || true)
+          echo "Found $COUNT coverage profile(s)"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No coverage profiles found"
+            echo "total=N/A" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$COUNT" -eq 1 ]; then
+            cp "$(echo "$PROFILES")" merged-coverage.out
+          else
+            go install github.com/wadey/gocovmerge@latest
+            echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
+          fi
+
+          TOTAL=$(awk '
+            /^mode:/ { next }
+            { stmts += $2; if ($3 > 0) covered += $2 }
+            END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
+          ' merged-coverage.out)
+          echo "Total coverage: $TOTAL"
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+
+          # Package-level summary grouped by top-level directory.
+          # go tool cover -func separates fields with variable numbers of tabs,
+          # so use $NF for the percentage and $1 for the path (default whitespace split).
+          go tool cover -func merged-coverage.out | grep -v '^total:' | \
+            awk '{
+              sub(/^github\.com\/hashicorp\/consul-dataplane\//, "", $1)
+              split($1, parts, "/")
+              pkg = parts[1]
+              gsub(/:.*/, "", pkg)
+              pct = $NF; gsub(/%/, "", pct)
+              sum[pkg] += pct; n[pkg]++
+            }
+            END {
+              for (pkg in sum) printf "%-35s %.1f%%\n", pkg, sum[pkg]/n[pkg]
+            }' | sort > pkg-summary.txt
+
+          {
+            echo "## Go Test Coverage"
+            echo ""
+            echo "**Total coverage: $TOTAL**"
+            echo ""
+            echo "| Package | Avg Coverage |"
+            echo "|---------|-------------|"
+            while IFS= read -r line; do
+              pkg=$(echo "$line" | awk '{print $1}')
+              pct=$(echo "$line" | awk '{print $2}')
+              echo "| \`$pkg\` | $pct |"
+            done < pkg-summary.txt
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          go tool cover -html=merged-coverage.out -o coverage.html
+
+      - name: Upload HTML coverage report
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: coverage-report-html
+          path: |
+            merged-coverage.out
+            coverage.html
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request' && steps.coverage.outputs.total != 'N/A'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ steps.coverage.outputs.total }}
+        run: |
+          BODY="### Go Test Coverage: **${TOTAL}**
+
+          See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report."
+
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" \
+            --body "$BODY" \
+            --edit-last 2>/dev/null || \
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" \
+            --body "$BODY"
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'
+        env:
+          TOTAL: ${{ steps.coverage.outputs.total }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PCT=$(echo "$TOTAL" | tr -d '%')
+          if awk "BEGIN {exit !($PCT >= 75)}"; then COLOR="brightgreen"
+          elif awk "BEGIN {exit !($PCT >= 60)}"; then COLOR="green"
+          elif awk "BEGIN {exit !($PCT >= 40)}"; then COLOR="yellow"
+          else COLOR="red"
+          fi
+
+          printf '{"schemaVersion":1,"label":"coverage","message":"%s","color":"%s"}\n' \
+            "$TOTAL" "$COLOR" > /tmp/coverage-badge.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          if git ls-remote --exit-code origin badges >/dev/null 2>&1; then
+            git fetch origin badges:badges --depth=1
+            git worktree add /tmp/badges-wt badges
+          else
+            git worktree add --detach /tmp/badges-wt HEAD
+            git -C /tmp/badges-wt checkout --orphan badges
+            git -C /tmp/badges-wt rm -rf . --quiet 2>/dev/null || true
+          fi
+
+          cp /tmp/coverage-badge.json /tmp/badges-wt/coverage.json
+          git -C /tmp/badges-wt add coverage.json
+          if git -C /tmp/badges-wt diff --staged --quiet; then
+            echo "Badge unchanged, skipping commit"
+          else
+            git -C /tmp/badges-wt commit -m "chore: update coverage badge [skip ci]"
+            git -C /tmp/badges-wt push origin HEAD:badges
+          fi

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -46,13 +46,20 @@ jobs:
             echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
           fi
 
+          # Exclude generated mock files — Go 1.20+ includes all compiled packages
+          # in the profile (even those without test files), which inflates the denominator.
           TOTAL=$(awk '
             /^mode:/ { next }
+            /\/mocks\/|\/mock_/ { next }
             { stmts += $2; if ($3 > 0) covered += $2 }
             END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
           ' merged-coverage.out)
           echo "Total coverage: $TOTAL"
           echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+
+          # Strip mock lines from profile before generating HTML and per-package summary.
+          grep -v -e '/mocks/' -e '/mock_' merged-coverage.out > filtered-coverage.out || true
+          mv filtered-coverage.out merged-coverage.out
 
           # Package-level summary grouped by top-level directory.
           # go tool cover -func separates fields with variable numbers of tabs,

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
   <span>Consul Dataplane</span>
 </h1>
 
+![Coverage](https://raw.githubusercontent.com/hashicorp/consul-dataplane/badges/coverage.svg)
+
 Consul Dataplane is a lightweight process that manages Envoy for Consul service mesh workloads.
 
 Consul Dataplane's design removes the need to run Consul client agents. Removing Consul client


### PR DESCRIPTION
Instruments unit-tests with -coverprofile, uploads the profile as an artifact, and adds a reusable-coverage-report workflow that merges profiles, computes the total with awk, posts a PR comment, and commits coverage.json to a badges branch on pushes to main.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
