### PR TITLE
ci: add Go test coverage reporting with Codecov

### DIFF
--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
 

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -103,24 +103,6 @@ jobs:
             merged-coverage.out
             coverage.html
 
-      - name: Post PR comment
-        if: github.event_name == 'pull_request' && steps.coverage.outputs.total != 'N/A'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TOTAL: ${{ steps.coverage.outputs.total }}
-        run: |
-          BODY="### Go Test Coverage: **${TOTAL}**
-
-          See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report."
-
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --repo "${{ github.repository }}" \
-            --body "$BODY" \
-            --edit-last 2>/dev/null || \
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --repo "${{ github.repository }}" \
-            --body "$BODY"
-
       - name: Upload to Codecov
         if: steps.coverage.outputs.total != 'N/A'
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write  # required for OIDC tokenless Codecov upload
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
@@ -119,6 +120,15 @@ jobs:
           gh pr comment ${{ github.event.pull_request.number }} \
             --repo "${{ github.repository }}" \
             --body "$BODY"
+
+      - name: Upload to Codecov
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          files: merged-coverage.out
+          use_oidc: true
+          fail_ci_if_error: false
+          verbose: false
 
       - name: Update coverage badge
         if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        # Allow up to 2% drop in overall project coverage before failing.
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        # New code introduced in a PR should be at least 70% covered.
+        target: 70%
+        threshold: 10%
+
+ignore:
+  - "internal/mocks/**"
+  - "pkg/**/mock_*.go"
+  - "integration-tests/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,14 +2,10 @@ coverage:
   status:
     project:
       default:
-        # Allow up to 2% drop in overall project coverage before failing.
-        target: auto
-        threshold: 2%
+        informational: true
     patch:
       default:
-        # New code introduced in a PR should be at least 70% covered.
-        target: 70%
-        threshold: 10%
+        informational: true
 
 ignore:
   - "internal/mocks/**"


### PR DESCRIPTION
## Description

Integrates Codecov for Go test coverage reporting.

### Changes

- Uploads the merged coverage profile to Codecov using OIDC tokenless auth — no stored secret required
- Adds `id-token: write` permission to the reusable workflow job and its caller
- Adds `codecov.yml` with informational-only status checks (non-blocking)
- Removes the custom PR comment in favour of Codecov's native comment, which includes diff coverage and a file-level breakdown

### Codecov dashboard

https://app.codecov.io/gh/hashicorp/consul-dataplane