### PR TITLE
Add legacy-server-compat flag for migration bridge to older consul servers.

### DIFF
--- a/.changelog/987.txt
+++ b/.changelog/987.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add `-legacy-server-compat` flag (env: `DP_LEGACY_SERVER_COMPAT`) to enable a time-bounded compatibility mode that allows newer consul-dataplane versions to connect to older Consul servers that do not yet advertise full dataplane feature support. This unblocks in-place Consul upgrades where the control plane and data plane cannot be updated simultaneously. Features unsupported by the older server are automatically disabled with structured warnings. This flag is intended for upgrade transitions only and must be removed once all Consul servers are running a fully supported version.
+```

--- a/cmd/consul-dataplane/config.go
+++ b/cmd/consul-dataplane/config.go
@@ -37,6 +37,9 @@ type ConsulFlags struct {
 	Addresses           *string `json:"addresses,omitempty"`
 	GRPCPort            *int    `json:"grpcPort,omitempty"`
 	ServerWatchDisabled *bool   `json:"serverWatchDisabled,omitempty"`
+	// EnableLegacyServerCompatibility activates the legacy-server compatibility mode
+	// for connecting to older Consul servers during in-place upgrades.
+	EnableLegacyServerCompatibility *bool `json:"legacyServerCompatibility,omitempty"`
 
 	TLS         TLSFlags         `json:"tls,omitempty"`
 	Credentials CredentialsFlags `json:"credentials,omitempty"`
@@ -288,9 +291,10 @@ func constructRuntimeConfig(cfg DataplaneConfigFlags, extraArgs []string) (*cons
 
 	return &consuldp.Config{
 		Consul: &consuldp.ConsulConfig{
-			Addresses:           stringVal(cfg.Consul.Addresses),
-			GRPCPort:            intVal(cfg.Consul.GRPCPort),
-			ServerWatchDisabled: boolVal(cfg.Consul.ServerWatchDisabled),
+			Addresses:                       stringVal(cfg.Consul.Addresses),
+			GRPCPort:                        intVal(cfg.Consul.GRPCPort),
+			ServerWatchDisabled:             boolVal(cfg.Consul.ServerWatchDisabled),
+			EnableLegacyServerCompatibility: boolVal(cfg.Consul.EnableLegacyServerCompatibility),
 			Credentials: &consuldp.CredentialsConfig{
 				Type: consuldp.CredentialsType(stringVal(cfg.Consul.Credentials.Type)),
 				Static: consuldp.StaticCredentialsConfig{

--- a/cmd/consul-dataplane/main.go
+++ b/cmd/consul-dataplane/main.go
@@ -46,6 +46,12 @@ func init() {
 
 	BoolVar(flags, &flagOpts.dataplaneConfig.Consul.ServerWatchDisabled, "server-watch-disabled", "DP_SERVER_WATCH_DISABLED", "Setting this prevents consul-dataplane from consuming the server update stream. This is useful for situations where Consul servers are behind a load balancer.")
 
+	BoolVar(flags, &flagOpts.dataplaneConfig.Consul.EnableLegacyServerCompatibility, "legacy-server-compat", "DP_LEGACY_SERVER_COMPAT",
+		"Enables a time-bounded compatibility mode that allows consul-dataplane to connect to older Consul servers "+
+			"that do not yet advertise full dataplane feature support, unblocking in-place Consul upgrades. "+
+			"Features unsupported by the older server are automatically disabled with a warning. "+
+			"WARNING: This is intended for upgrade transitions only and must be removed once all Consul servers are on a fully supported version.")
+
 	StringVar(flags, &flagOpts.dataplaneConfig.Logging.LogLevel, "log-level", "DP_LOG_LEVEL", "Log level of the messages to print. "+
 		"Available log levels are \"trace\", \"debug\", \"info\", \"warn\", and \"error\".")
 

--- a/pkg/consuldp/bootstrap.go
+++ b/pkg/consuldp/bootstrap.go
@@ -116,17 +116,28 @@ func (cdp *ConsulDataplane) bootstrapConfig(
 	}
 
 	if cdp.cfg.Telemetry.UseCentralConfig {
-		if err := mapstructure.WeakDecode(bootstrapParams.Config.AsMap(), &bootstrapConfig); err != nil {
-			return nil, nil, fmt.Errorf("failed parsing Proxy.Config: %w", err)
-		}
+		// Legacy-compat guard: older servers may return a nil proxy config
+		// struct inside the bootstrap params response. Calling AsMap() on a
+		// nil proto message panics. Skip central config and warn the operator.
+		if cdp.isLegacyCompatMode {
+			cdp.logger.Warn("[COMPAT] skipping central telemetry configuration: " +
+				"the connected Consul server does not support all required dataplane features. " +
+				"Re-enable central telemetry config after upgrading to a fully supported Consul version.")
+		} else if bootstrapParams.Config == nil {
+			cdp.logger.Warn("skipping central telemetry configuration: server returned no proxy config")
+		} else {
+			if err := mapstructure.WeakDecode(bootstrapParams.Config.AsMap(), &bootstrapConfig); err != nil {
+				return nil, nil, fmt.Errorf("failed parsing Proxy.Config: %w", err)
+			}
 
-		// Envoy is configured with a listener that proxies metrics from its
-		// own admin endpoint (localhost:19000/stats/prometheus). When central
-		// config is enabled, we set the PrometheusBackendPort to instead have
-		// Envoy proxy metrics from Consul Dataplane which serves merged
-		// metrics (Envoy + Dataplane + service metrics).
-		// Documentation: https://www.consul.io/commands/connect/envoy#prometheus-backend-port
-		args.PrometheusBackendPort = strconv.Itoa(prom.MergePort)
+			// Envoy is configured with a listener that proxies metrics from its
+			// own admin endpoint (localhost:19000/stats/prometheus). When central
+			// config is enabled, we set the PrometheusBackendPort to instead have
+			// Envoy proxy metrics from Consul Dataplane which serves merged
+			// metrics (Envoy + Dataplane + service metrics).
+			// Documentation: https://www.consul.io/commands/connect/envoy#prometheus-backend-port
+			args.PrometheusBackendPort = strconv.Itoa(prom.MergePort)
+		}
 	}
 
 	bootstrapConfig.Logger = cdp.logger.Named("bootstrap-config")

--- a/pkg/consuldp/config.go
+++ b/pkg/consuldp/config.go
@@ -30,6 +30,23 @@ type ConsulConfig struct {
 	ServerWatchDisabled bool
 	// TLS contains the TLS settings for communicating with Consul servers.
 	TLS *TLSConfig
+	// EnableLegacyServerCompatibility activates a limited, time-bounded
+	// compatibility mode that allows newer consul-dataplane versions to connect
+	// to older Consul servers that do not yet advertise full dataplane feature
+	// support. It is designed to unblock in-place Consul upgrades when the
+	// control plane and data plane cannot be updated simultaneously.
+	//
+	// When enabled:
+	//   - The server feature gate is bypassed for the initial handshake.
+	//   - Features unsupported by the older server (e.g. central telemetry
+	//     configuration) are automatically disabled with a warning.
+	//   - All compatibility decisions are emitted as structured log events so
+	//     operators can track impact and verify readiness.
+	//
+	// WARNING: This flag is NOT intended for long-term or permanent use.
+	// It exists solely to unblock the upgrade path. Remove it once all
+	// Consul servers have been upgraded to a fully supported version.
+	EnableLegacyServerCompatibility bool
 }
 
 // DNSServerConfig is the configuration for the transparent DNS proxy that will forward requests to consul

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -24,6 +24,29 @@ import (
 	metricscache "github.com/hashicorp/consul-dataplane/pkg/metrics-cache"
 )
 
+// knownDataplaneFeatures is the ordered set of feature names that a fully-capable
+// Consul server is expected to advertise. It is used by categorizeFeatures
+// to produce available_features / missing_features log fields.
+var knownDataplaneFeatures = []string{
+	pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_WATCH_SERVERS.String(),
+	pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_EDGE_CERTIFICATE_MANAGEMENT.String(),
+	pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION.String(),
+}
+
+// categorizeFeatures splits the server's advertised feature map into
+// "available" and "missing" slices relative to the given expected set.
+// The resulting slices are suitable for structured log key-value fields.
+func categorizeFeatures(expected []string, advertised map[string]bool) (available, missing []string) {
+	for _, f := range expected {
+		if advertised[f] {
+			available = append(available, f)
+		} else {
+			missing = append(missing, f)
+		}
+	}
+	return
+}
+
 type xdsServer struct {
 	listener        net.Listener
 	listenerAddress string
@@ -47,6 +70,13 @@ type ConsulDataplane struct {
 	aclToken        string
 	metricsConfig   *metricsConfig
 	lifecycleConfig *lifecycleConfig
+
+	// isLegacyCompatMode is true when we are connected to a Consul server that
+	// does not advertise full dataplane feature support. Some optional features
+	// are automatically disabled or guarded to prevent failures against the
+	// older API surface. Set conservatively at construction time and refined
+	// once the server's actual feature set is known.
+	isLegacyCompatMode bool
 }
 
 // NewConsulDP creates a new instance of ConsulDataplane
@@ -68,7 +98,26 @@ func NewConsulDP(cfg *Config) (*ConsulDataplane, error) {
 	return &ConsulDataplane{
 		logger: logger,
 		cfg:    cfg,
+		// Conservatively pre-set legacy compat mode from the config flag so that
+		// any code running before watcher.State() resolves already applies
+		// compatibility guards. The value is refined once the server's actual
+		// feature set is known.
+		isLegacyCompatMode: cfg.Consul.EnableLegacyServerCompatibility,
 	}, nil
+}
+
+// legacyCompatDisabledFeatures returns the authoritative list of consul-dataplane
+// features that are intentionally disabled while in legacy-server compatibility
+// mode. This is the single place to expand the list as new guards are added.
+func (cdp *ConsulDataplane) legacyCompatDisabledFeatures() []string {
+	if !cdp.isLegacyCompatMode {
+		return nil
+	}
+	return []string{
+		// The proxy config struct returned by older servers may be absent,
+		// so central telemetry config decoding is skipped to avoid a panic.
+		"central-telemetry-config",
+	}
 }
 
 func validateConfig(cfg *Config) error {
@@ -153,15 +202,55 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 		return err
 	}
 
+	var serverEvalFn discovery.ServerEvalFn
+
+	if cdp.cfg.Consul.EnableLegacyServerCompatibility {
+		cdp.logger.Warn("[COMPAT] legacy-server-compat is enabled — "+
+			"consul-dataplane will bypass the normal dataplane feature check to allow connection to older Consul servers. "+
+			"Features not supported by the server will be automatically disabled. "+
+			"This flag is intended for upgrade transitions only. "+
+			"Remove it once all Consul servers are on a fully supported version.",
+			"disabled_features", cdp.legacyCompatDisabledFeatures(),
+		)
+		// Controlled bypass: always accept the server but classify its features
+		// so anomalies (e.g. a fully-capable server with the flag still on) are
+		// immediately visible to the operator.
+		bootstrapFeature := pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION.String()
+		serverEvalFn = func(s discovery.State) bool {
+			available, missing := categorizeFeatures(knownDataplaneFeatures, s.DataplaneFeatures)
+			if s.DataplaneFeatures[bootstrapFeature] {
+				// Anomaly: this server already has full feature support. The flag
+				// is redundant — warn so the operator can clean it up.
+				cdp.logger.Warn("[COMPAT] server has full dataplane feature support — "+
+					"the legacy-server-compat flag is not required for this server. "+
+					"Consider removing it after verifying your environment.",
+					"server_address", s.Address.String(),
+					"available_features", available,
+					"missing_features", missing,
+				)
+			} else {
+				// Expected path: server lacks the bootstrap feature (older server).
+				cdp.logger.Info("[COMPAT] accepting server in legacy compatibility mode",
+					"server_address", s.Address.String(),
+					"available_features", available,
+					"missing_features", missing,
+				)
+			}
+			return true
+		}
+	} else {
+		serverEvalFn = discovery.SupportsDataplaneFeatures(
+			pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION.String(),
+		)
+	}
+
 	watcher, err := discovery.NewWatcher(ctx, discovery.Config{
 		Addresses:           cdp.cfg.Consul.Addresses,
 		GRPCPort:            cdp.cfg.Consul.GRPCPort,
 		ServerWatchDisabled: cdp.cfg.Consul.ServerWatchDisabled,
 		Credentials:         creds,
 		TLS:                 tls,
-		ServerEvalFn: discovery.SupportsDataplaneFeatures(
-			pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION.String(),
-		),
+		ServerEvalFn:        serverEvalFn,
 	}, cdp.logger.Named("server-connection-manager"))
 	if err != nil {
 		return err
@@ -178,6 +267,35 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 	cdp.serverConn = state.GRPCConn
 	cdp.aclToken = state.Token
 	cdp.dpServiceClient = pbdataplane.NewDataplaneServiceClient(state.GRPCConn)
+
+	// Refine isLegacyCompatMode using the server's actual advertised feature set.
+	// The value was pre-set conservatively in NewConsulDP; here we either
+	// confirm it (server lacks required features) or downgrade it (server is
+	// fully capable despite the flag being set).
+	if cdp.isLegacyCompatMode {
+		bootstrapFeature := pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION.String()
+		available, missing := categorizeFeatures(knownDataplaneFeatures, state.DataplaneFeatures)
+		if state.DataplaneFeatures[bootstrapFeature] {
+			// Server is fully capable — downgrade to normal operation.
+			cdp.isLegacyCompatMode = false
+			cdp.logger.Info("[COMPAT] server has full dataplane feature support — "+
+				"compatibility guards have been lifted. "+
+				"Consider removing the legacy-server-compat flag.",
+				"server_address", state.Address.String(),
+				"available_features", available,
+				"missing_features", missing,
+			)
+		} else {
+			// Confirmed: server lacks required features — keep compat mode active.
+			cdp.logger.Warn("[COMPAT] server does not support all required dataplane features — "+
+				"running in legacy compatibility mode with reduced feature set.",
+				"server_address", state.Address.String(),
+				"available_features", available,
+				"missing_features", missing,
+				"disabled_features", cdp.legacyCompatDisabledFeatures(),
+			)
+		}
+	}
 
 	doneCh := make(chan error)
 

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -106,10 +106,10 @@ func NewConsulDP(cfg *Config) (*ConsulDataplane, error) {
 	}, nil
 }
 
-// legacyCompatDisabledFeatures returns the authoritative list of consul-dataplane
+// disabledFeaturesCompatibilityMode returns the authoritative list of consul-dataplane
 // features that are intentionally disabled while in legacy-server compatibility
 // mode. This is the single place to expand the list as new guards are added.
-func (cdp *ConsulDataplane) legacyCompatDisabledFeatures() []string {
+func (cdp *ConsulDataplane) disabledFeaturesCompatibilityMode() []string {
 	if !cdp.isLegacyCompatMode {
 		return nil
 	}
@@ -210,7 +210,7 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 			"Features not supported by the server will be automatically disabled. "+
 			"This flag is intended for upgrade transitions only. "+
 			"Remove it once all Consul servers are on a fully supported version.",
-			"disabled_features", cdp.legacyCompatDisabledFeatures(),
+			"disabled_features", cdp.disabledFeaturesCompatibilityMode(),
 		)
 		// Controlled bypass: always accept the server but classify its features
 		// so anomalies (e.g. a fully-capable server with the flag still on) are
@@ -292,7 +292,7 @@ func (cdp *ConsulDataplane) Run(ctx context.Context) error {
 				"server_address", state.Address.String(),
 				"available_features", available,
 				"missing_features", missing,
-				"disabled_features", cdp.legacyCompatDisabledFeatures(),
+				"disabled_features", cdp.disabledFeaturesCompatibilityMode(),
 			)
 		}
 	}

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -337,3 +337,85 @@ func TestNewConsulDPError(t *testing.T) {
 		})
 	}
 }
+
+// TestCategorizeFeatures verifies that categorizeFeatures correctly splits
+// a server's advertised feature map into available and missing slices.
+func TestCategorizeFeatures(t *testing.T) {
+	all := []string{"FEATURE_A", "FEATURE_B", "FEATURE_C"}
+
+	tests := []struct {
+		name              string
+		advertised        map[string]bool
+		expectedAvailable []string
+		expectedMissing   []string
+	}{
+		{
+			name:              "server advertises all features",
+			advertised:        map[string]bool{"FEATURE_A": true, "FEATURE_B": true, "FEATURE_C": true},
+			expectedAvailable: []string{"FEATURE_A", "FEATURE_B", "FEATURE_C"},
+			expectedMissing:   nil,
+		},
+		{
+			name:              "server advertises no features",
+			advertised:        map[string]bool{},
+			expectedAvailable: nil,
+			expectedMissing:   []string{"FEATURE_A", "FEATURE_B", "FEATURE_C"},
+		},
+		{
+			name:              "server advertises some features",
+			advertised:        map[string]bool{"FEATURE_A": true, "FEATURE_C": true},
+			expectedAvailable: []string{"FEATURE_A", "FEATURE_C"},
+			expectedMissing:   []string{"FEATURE_B"},
+		},
+		{
+			name:              "server advertises a feature not in expected list",
+			advertised:        map[string]bool{"FEATURE_A": true, "FEATURE_UNKNOWN": true},
+			expectedAvailable: []string{"FEATURE_A"},
+			expectedMissing:   []string{"FEATURE_B", "FEATURE_C"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			available, missing := categorizeFeatures(all, tc.advertised)
+			require.Equal(t, tc.expectedAvailable, available)
+			require.Equal(t, tc.expectedMissing, missing)
+		})
+	}
+}
+
+// TestLegacyCompatDisabledFeatures verifies that legacyCompatDisabledFeatures
+// returns the correct list only when compatibility mode is active.
+func TestLegacyCompatDisabledFeatures(t *testing.T) {
+	t.Run("returns disabled features when in legacy compat mode", func(t *testing.T) {
+		cdp := &ConsulDataplane{isLegacyCompatMode: true}
+		disabled := cdp.legacyCompatDisabledFeatures()
+		require.Equal(t, []string{"central-telemetry-config"}, disabled)
+	})
+
+	t.Run("returns nil when not in legacy compat mode", func(t *testing.T) {
+		cdp := &ConsulDataplane{isLegacyCompatMode: false}
+		disabled := cdp.legacyCompatDisabledFeatures()
+		require.Nil(t, disabled)
+	})
+}
+
+// TestNewConsulDP_LegacyServerCompatMode verifies that NewConsulDP correctly
+// sets isLegacyCompatMode from the EnableLegacyServerCompatibility config field.
+func TestNewConsulDP_LegacyServerCompatMode(t *testing.T) {
+	t.Run("isLegacyCompatMode is true when flag is enabled", func(t *testing.T) {
+		cfg := validConfig(ModeTypeSidecar)
+		cfg.Consul.EnableLegacyServerCompatibility = true
+		cdp, err := NewConsulDP(cfg)
+		require.NoError(t, err)
+		require.True(t, cdp.isLegacyCompatMode)
+	})
+
+	t.Run("isLegacyCompatMode is false when flag is not set", func(t *testing.T) {
+		cfg := validConfig(ModeTypeSidecar)
+		cfg.Consul.EnableLegacyServerCompatibility = false
+		cdp, err := NewConsulDP(cfg)
+		require.NoError(t, err)
+		require.False(t, cdp.isLegacyCompatMode)
+	})
+}

--- a/pkg/consuldp/consul_dataplane_test.go
+++ b/pkg/consuldp/consul_dataplane_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul-server-connection-manager/discovery"
+	"github.com/hashicorp/consul/proto-public/pbdataplane"
 	"github.com/stretchr/testify/require"
 )
 
@@ -384,18 +386,18 @@ func TestCategorizeFeatures(t *testing.T) {
 	}
 }
 
-// TestLegacyCompatDisabledFeatures verifies that legacyCompatDisabledFeatures
+// TestDisabledFeaturesCompatibilityMode verifies that disabledFeaturesCompatibilityMode
 // returns the correct list only when compatibility mode is active.
-func TestLegacyCompatDisabledFeatures(t *testing.T) {
+func TestDisabledFeaturesCompatibilityMode(t *testing.T) {
 	t.Run("returns disabled features when in legacy compat mode", func(t *testing.T) {
 		cdp := &ConsulDataplane{isLegacyCompatMode: true}
-		disabled := cdp.legacyCompatDisabledFeatures()
+		disabled := cdp.disabledFeaturesCompatibilityMode()
 		require.Equal(t, []string{"central-telemetry-config"}, disabled)
 	})
 
 	t.Run("returns nil when not in legacy compat mode", func(t *testing.T) {
 		cdp := &ConsulDataplane{isLegacyCompatMode: false}
-		disabled := cdp.legacyCompatDisabledFeatures()
+		disabled := cdp.disabledFeaturesCompatibilityMode()
 		require.Nil(t, disabled)
 	})
 }
@@ -414,8 +416,43 @@ func TestNewConsulDP_LegacyServerCompatMode(t *testing.T) {
 	t.Run("isLegacyCompatMode is false when flag is not set", func(t *testing.T) {
 		cfg := validConfig(ModeTypeSidecar)
 		cfg.Consul.EnableLegacyServerCompatibility = false
+		// NewConsulDP only constructs the struct it does not connect to a server,
+		// so no error is expected here regardless of the flag value. The actual
+		// server rejection (when legacy mode is off and the server lacks the required
+		// feature) happens later in Run() via serverEvalFn. That behaviour is
+		// covered by TestServerEvalFn_LegacyCompatDisabled.
 		cdp, err := NewConsulDP(cfg)
 		require.NoError(t, err)
 		require.False(t, cdp.isLegacyCompatMode)
+	})
+}
+
+// TestServerEvalFn_LegacyCompatDisabled verifies that when legacy-server-compat
+// is NOT enabled, a server that does not advertise
+// DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION is rejected (serverEvalFn
+// returns false). This is the unchanged default behaviour that the flag must
+// not silently break.
+func TestServerEvalFn_LegacyCompatDisabled(t *testing.T) {
+	bootstrapFeature := pbdataplane.DataplaneFeatures_DATAPLANE_FEATURES_ENVOY_BOOTSTRAP_CONFIGURATION.String()
+	serverEvalFn := discovery.SupportsDataplaneFeatures(bootstrapFeature)
+
+	t.Run("rejects server missing bootstrap feature when legacy mode is disabled", func(t *testing.T) {
+		state := discovery.State{
+			DataplaneFeatures: map[string]bool{
+				// Server does NOT advertise the required feature.
+			},
+		}
+		require.False(t, serverEvalFn(state),
+			"expected server to be rejected when bootstrap feature is missing and legacy-server-compat is disabled")
+	})
+
+	t.Run("accepts server with bootstrap feature when legacy mode is disabled", func(t *testing.T) {
+		state := discovery.State{
+			DataplaneFeatures: map[string]bool{
+				bootstrapFeature: true,
+			},
+		}
+		require.True(t, serverEvalFn(state),
+			"expected server to be accepted when bootstrap feature is present")
 	})
 }


### PR DESCRIPTION
## Changes applied
- Adding a legacy flag for helping one of our customer for migration from 1.18.x to 1.21.x this flag allows the user to connect the older consul version i.e. 1.18.x with consul-dataplane 1.8.x
