### PR TITLE
Backport of fix: patch golang.org/x/net and align FIPS UBI base image in Dockerfile into release/1.8.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,14 @@ RUN setcap CAP_NET_BIND_SERVICE=+ep /usr/local/bin/$BIN_NAME
 # either).
 ARG GOLANG_VERSION
 FROM golang:${GOLANG_VERSION}-alpine as go-discover
-RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@02bc47fc98440860b5615a96300b95a065add1f2
+RUN apk add --no-cache git
+RUN git clone https://github.com/hashicorp/go-discover.git /src/go-discover && \
+    cd /src/go-discover && \
+    git checkout ca13b81fe744b323d3730020a898a288ce502069 && \
+    go get golang.org/x/net@v0.55.0 && \
+    go get golang.org/x/crypto@v0.52.0 && \
+    go mod tidy && \
+    CGO_ENABLED=0 go build -o /go/bin/discover ./cmd/discover
 
 # Pull in dumb-init from alpine, as our distroless release image doesn't have a
 # package manager and there's no RPM package for UBI.
@@ -192,7 +199,7 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/consul-dataplane"]
 # This image is based on the Red Hat UBI base image, and has the necessary
 # labels, license file, and non-root user.
 # -----------------------------------
-FROM registry.access.redhat.com/ubi9-minimal:9.7 as release-fips-ubi
+FROM registry.access.redhat.com/ubi9-minimal:9.8 as release-fips-ubi
 
 ARG BIN_NAME
 ENV BIN_NAME=$BIN_NAME


### PR DESCRIPTION
Manual Backport from https://github.com/hashicorp/consul-dataplane/pull/1113 to be assessed for backporting due to the inclusion of the label backport/1.8.