### PR TITLE
backport chore: clean up resolved suppressions from security-scan.hcl 1.9.x

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -29,14 +29,6 @@ container {
       vulnerabilities = [
       ]
       paths = [
-        // The OSV scanner will trip on several packages that are included in the
-        // the UBI images. This is due to RHEL using the same base version in the
-        // package name for the life of the distro regardless of whether or not
-        // that version has been patched for security. Rather than enumate ever
-        // single CVE that the OSV scanner will find (several tens) we'll ignore
-        // the base UBI packages.
-        "usr/lib/sysimage/rpm/*",
-        "var/lib/rpm/*",
       ]
     }
   }
@@ -62,7 +54,6 @@ repository {
 
   triage {
     suppress {
-      # Only remaining vulnerabilities in integration tests (archived go-jose v2)
       vulnerabilities = []
       paths = [
         # SHA1 usage in bootstrap config is for non-security purposes


### PR DESCRIPTION
Manual backport from https://github.com/hashicorp/consul-dataplane/pull/1108 to be assessed for backporting due to the inclusion of the label backport/1.9.