### PR TITLE
chore: suppress OSV scanner false positives for UBI base RPM paths

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -30,6 +30,14 @@ container {
  
       ]
       paths = [
+        // The OSV scanner will trip on several packages that are included in the
+        // the UBI images. This is due to RHEL using the same base version in the
+        // package name for the life of the distro regardless of whether or not
+        // that version has been patched for security. Rather than enumate ever
+        // single CVE that the OSV scanner will find (several tens) we'll ignore
+        // the base UBI packages.
+        "usr/lib/sysimage/rpm/*",
+        "var/lib/rpm/*",
       ]
     }
   }


### PR DESCRIPTION
Add path suppressions for `usr/lib/sysimage/rpm/*` and `var/lib/rpm/*`
in the container triage block. The OSV scanner flags these due to RHEL's
policy of keeping the base version in package names regardless of applied
patches, producing spurious CVE findings for UBI image base packages.