### PR TITLE
fix(ci): increase max-issue budget for stale branch cleanup

### DIFF
--- a/.github/workflows/stale-branches.yaml
+++ b/.github/workflows/stale-branches.yaml
@@ -2,6 +2,7 @@ name: Stale Branches
 on:
   schedule:
     - cron: "0 6 * * 1-5"
+  workflow_dispatch:
 
 permissions:
   issues: write
@@ -11,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale Branches
-        uses: crs-k/stale-branches@c6e09a3de1046d68b21eccdca23321d0ec277964 # v7.0.0
+        uses: crs-k/stale-branches@e876b957ab08f0bad43c8cc271a22cdd7604bd09 # v9.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           days-before-stale: 120
@@ -22,3 +23,4 @@ jobs:
           compare-branches: "info"
           ignore-issue-interaction: true
           pr-check: true
+          max-issues: 500


### PR DESCRIPTION
## Description
- Increased max-issue input to stale-branch workflow from defalt 20 to allow processing of all the branches
- Upgraded crs-k/stale-branches version in stale-branch workflow to latest

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
