### PR TITLE
update envoy version to 1.38.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-ARG ENVOY_VERSION=1.37.4
+ARG ENVOY_VERSION=1.38.2
 FROM hashicorp/envoy:${ENVOY_VERSION} AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).


### PR DESCRIPTION
## Description

- Bumps the bundled Envoy version from 1.37.4 to 1.38.2.