### PR TITLE
ci: enforce 90% patch coverage merge gate

### DIFF
--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -46,6 +46,65 @@ jobs:
       id-token: write
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
+      pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
+
+  coverage-gate:
+    name: coverage-gate
+    needs: [coverage-report]
+    # Patch coverage measures the lines a PR adds/modifies, so it only applies
+    # to pull requests. Pushes to main run coverage-report for the badge but
+    # have no "patch" to evaluate. Only gate when the report succeeded.
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      # Minimum required coverage of the lines a PR adds/modifies (patch
+      # coverage). New/changed code must be at least this well tested.
+      PATCH_THRESHOLD: "90"
+    steps:
+      - name: Enforce patch coverage threshold
+        env:
+          PATCH: ${{ needs.coverage-report.outputs.patch }}
+          COVERED: ${{ needs.coverage-report.outputs.patch_covered }}
+          COVERABLE: ${{ needs.coverage-report.outputs.patch_coverable }}
+        run: |
+          set -euo pipefail
+
+          echo "Patch coverage:     ${PATCH:-<empty>}"
+          echo "Required threshold: ${PATCH_THRESHOLD}%"
+          echo "Changed lines:      ${COVERED:-0}/${COVERABLE:-0} covered"
+
+          # No coverable Go lines changed (docs/test-only) -> nothing to gate.
+          if [ -z "${PATCH}" ] || [ "${PATCH}" = "N/A" ]; then
+            echo "::notice::No coverable Go lines changed in this PR; patch-coverage gate skipped."
+            {
+              echo "### ✅ Coverage gate passed"
+              echo ""
+              echo "No coverable Go lines changed in this PR, so there is nothing to gate."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          PCT="${PATCH%\%}"
+
+          if awk "BEGIN { exit !(${PCT} >= ${PATCH_THRESHOLD}) }"; then
+            echo "::notice::Patch coverage ${PATCH} meets the ${PATCH_THRESHOLD}% threshold."
+            {
+              echo "### ✅ Coverage gate passed"
+              echo ""
+              echo "Patch coverage **${PATCH}** (${COVERED}/${COVERABLE} changed lines) ≥ required **${PATCH_THRESHOLD}%**."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Patch coverage ${PATCH} is below the required ${PATCH_THRESHOLD}% threshold."
+            {
+              echo "### ❌ Coverage gate failed"
+              echo ""
+              echo "Patch coverage **${PATCH}** (${COVERED}/${COVERABLE} changed lines) is below the required **${PATCH_THRESHOLD}%** threshold."
+              echo ""
+              echo "The lines this PR adds or modifies are not sufficiently covered by tests."
+              echo "Add tests for the new/changed code, or adjust \`PATCH_THRESHOLD\` in \`.github/workflows/consul-dataplane-checks.yaml\` (with reviewer sign-off)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
   integration-tests:
     name: integration-tests

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -46,7 +46,7 @@ jobs:
       id-token: write
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
-      pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
+      pr-number: ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.number) || '' }}
 
   coverage-gate:
     name: coverage-gate

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -74,7 +74,20 @@ jobs:
           echo "Changed lines:      ${COVERED:-0}/${COVERABLE:-0} covered"
 
           # No coverable Go lines changed (docs/test-only) -> nothing to gate.
-          if [ -z "${PATCH}" ] || [ "${PATCH}" = "N/A" ]; then
+          # Fail closed: an empty PATCH means the reusable workflow could not
+          # compute patch coverage (no coverage profile produced, so the patch
+          # step was skipped). Don't let the gate pass unevaluated.
+          if [ -z "${PATCH}" ]; then
+            echo "::error::Patch coverage was not computed (no coverage profile produced). Failing closed."
+            {
+              echo "### ❌ Coverage gate failed"
+              echo ""
+              echo "Patch coverage could not be computed because no coverage profile was produced (unit tests may not have run or emitted coverage)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if [ "${PATCH}" = "N/A" ]; then
             echo "::notice::No coverable Go lines changed in this PR; patch-coverage gate skipped."
             {
               echo "### ✅ Coverage gate passed"

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -6,6 +6,28 @@ on:
       go-version:
         required: true
         type: string
+      pr-number:
+        required: false
+        type: string
+    outputs:
+      total:
+        description: >-
+          Total computed coverage as a percentage string (e.g. "67.0%"), or
+          "N/A" when no coverage profiles were found.
+        value: ${{ jobs.report.outputs.total }}
+      patch:
+        description: >-
+          Patch coverage: the percentage of the non-test, non-mock Go lines this
+          PR adds/modifies that are covered by tests. "N/A" when the PR changes
+          no coverable Go lines. Consumed by the coverage-gate job to enforce a
+          minimum patch-coverage threshold.
+        value: ${{ jobs.report.outputs.patch }}
+      patch_covered:
+        description: Number of changed coverable lines that are covered.
+        value: ${{ jobs.report.outputs.patch_covered }}
+      patch_coverable:
+        description: Number of changed coverable lines in the PR.
+        value: ${{ jobs.report.outputs.patch_coverable }}
 
 jobs:
   report:
@@ -14,6 +36,11 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write  # required for OIDC tokenless Codecov upload
+    outputs:
+      total: ${{ steps.coverage.outputs.total }}
+      patch: ${{ steps.patch.outputs.patch }}
+      patch_covered: ${{ steps.patch.outputs.covered }}
+      patch_coverable: ${{ steps.patch.outputs.coverable }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
@@ -93,6 +120,139 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           go tool cover -html=merged-coverage.out -o coverage.html
+
+      - name: Compute patch coverage
+        id: patch
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr-number }}
+          REPO: ${{ github.repository }}
+          MODULE: github.com/hashicorp/consul-dataplane
+        run: |
+          set -euo pipefail
+
+          # 1) Collect the lines this PR adds/modifies for non-test, non-mock Go
+          #    files, read straight from the PR diff via the API, emitting
+          #    "<import-path>\t<lineno>". merged-coverage.out is already filtered
+          #    (mocks removed), so changed lines in those paths never intersect a
+          #    block and are ignored as non-coverable.
+          gh api --paginate "repos/${REPO}/pulls/${PR}/files" \
+            --jq '.[]
+                  | select(.filename | test("\\.go$"))
+                  | select(.filename | test("_test\\.go$") | not)
+                  | select(.filename | test("(^|/)mocks/|(^|/)mock_") | not)
+                  | if .patch == null
+                    then "NULLPATCH\t\(.filename)"
+                    else "FILE\t\(.filename)\n\(.patch)"
+                    end' > /tmp/pr-patches.txt
+
+          # This is a merge gate, so fail closed: a coverable .go file whose
+          # diff the API cannot return (.patch == null, e.g. the file's diff is
+          # too large to render) must not be silently treated as zero changed
+          # lines and let the gate pass.
+          if grep -q '^NULLPATCH\t' /tmp/pr-patches.txt; then
+            echo "::error::Cannot compute patch coverage: the GitHub API returned no diff (patch == null) for changed Go file(s):"
+            grep '^NULLPATCH\t' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
+            echo "This usually means a single file's diff is too large for the API to render. Split the change so coverage can be measured."
+            exit 1
+          fi
+
+          awk -v module="$MODULE" '
+            /^FILE\t/ { file=$2; next }
+            /^@@ / {
+              # @@ -a,b +c,d @@  -> new-file hunk starts at line c
+              plus=$3; sub(/^\+/, "", plus); split(plus, a, ","); newline=a[1]; next
+            }
+            /^\\/ { next }                          # e.g. "\ No newline at end of file": not a real line
+            {
+              if (file=="") next
+              ch=substr($0,1,1)
+              if (ch=="+")      { print module"/"file"\t"newline; newline++ }
+              else if (ch=="-") { }                  # removed line: no new-file number
+              else              { newline++ }         # context line advances pointer
+            }
+          ' /tmp/pr-patches.txt > /tmp/changed-lines.txt
+
+          # 2) Intersect changed lines with the (already filtered) coverage
+          #    profile. A changed line is "coverable" if it falls inside any
+          #    profile block, and "covered" if any such block has a hit count > 0.
+          awk '
+            BEGIN { NB = 0 }
+            FNR==NR {
+              if ($0 ~ /^mode:/) next
+              n=split($1, p, ":"); f=p[1]
+              split(p[2], rr, ","); split(rr[1], s, "."); split(rr[2], e, ".")
+              blkF[NB]=f; blkS[NB]=s[1]; blkE[NB]=e[1]; blkC[NB]=$3; NB++
+              next
+            }
+            {
+              f=$1; L=$2; coverable=0; covered=0
+              for (i=0; i<NB; i++) {
+                if (blkF[i]==f && L>=blkS[i] && L<=blkE[i]) {
+                  coverable=1; if (blkC[i]>0) covered=1
+                }
+              }
+              if (coverable) { tot++; if (covered) cov++ }
+            }
+            END {
+              if (tot==0) { print "patch=N/A"; print "covered=0"; print "coverable=0" }
+              else { printf "patch=%.1f%%\n", cov/tot*100; print "covered="cov; print "coverable="tot }
+            }
+          ' merged-coverage.out /tmp/changed-lines.txt > /tmp/patch-result.txt
+
+          PATCH=$(awk -F= '/^patch=/{print $2}' /tmp/patch-result.txt)
+          COVD=$(awk -F= '/^covered=/{print $2}' /tmp/patch-result.txt)
+          COVB=$(awk -F= '/^coverable=/{print $2}' /tmp/patch-result.txt)
+          echo "Patch coverage: ${PATCH} (${COVD}/${COVB} changed coverable lines)"
+          {
+            echo "patch=${PATCH}"
+            echo "covered=${COVD}"
+            echo "coverable=${COVB}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ steps.coverage.outputs.total }}
+          PATCH: ${{ steps.patch.outputs.patch }}
+          PATCH_COVD: ${{ steps.patch.outputs.covered }}
+          PATCH_COVB: ${{ steps.patch.outputs.coverable }}
+        run: |
+          MARKER="<!-- coverage-report-comment -->"
+          if [ -z "${PATCH:-}" ] || [ "${PATCH:-N/A}" = "N/A" ]; then
+            PATCH_LINE="**Patch coverage:** N/A (no coverable Go lines changed)"
+          else
+            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered)"
+          fi
+          BODY=$(cat <<EOF
+          ${MARKER}
+
+          ### Go Test Coverage: **${TOTAL}**
+
+          ${PATCH_LINE}
+
+          See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full per-package breakdown and downloadable HTML report.
+          EOF
+          )
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- coverage-report-comment -->"))) | .id' \
+            | tail -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -f body="$BODY"
+          else
+            gh pr comment ${{ inputs.pr-number }} \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          fi
 
       - name: Upload HTML coverage report
         if: steps.coverage.outputs.total != 'N/A'

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -151,9 +151,9 @@ jobs:
           # diff the API cannot return (.patch == null, e.g. the file's diff is
           # too large to render) must not be silently treated as zero changed
           # lines and let the gate pass.
-          if grep -q '^NULLPATCH\t' /tmp/pr-patches.txt; then
+          if grep -q '^NULLPATCH' /tmp/pr-patches.txt; then
             echo "::error::Cannot compute patch coverage: the GitHub API returned no diff (patch == null) for changed Go file(s):"
-            grep '^NULLPATCH\t' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
+            grep '^NULLPATCH' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
             echo "This usually means a single file's diff is too large for the API to render. Split the change so coverage can be measured."
             exit 1
           fi


### PR DESCRIPTION
## Summary
Adds a deterministic **90% patch-coverage merge gate** to consul-dataplane, matching the gate rolled out across consul, consul-k8s, consul-ecs, consul-esm, and consul-terraform-sync.

Patch coverage = % of the **new/changed** non-test, non-mock Go lines a PR adds that are covered by tests. The gate fails if patch coverage < 90%; total coverage (badge + Codecov) stays informational.

## Changes
- **reusable-coverage-report.yml**: adds `pr-number` input and `total`/`patch`/`patch_covered`/`patch_coverable` outputs; computes patch coverage by intersecting the PR diff with the merged Go profile; posts/updates a single PR comment. Fails closed if the API returns no diff (`patch == null`) for a changed coverable file.
- **consul-dataplane-checks.yaml**: passes `pr-number`; adds a `coverage-gate` job enforcing `PATCH_THRESHOLD: 90` on pull requests only.

## Notes
- Single module, `github.com/hashicorp/consul-dataplane`; no `.pb.go` in-repo, mocks excluded.
- Make **coverage-gate** a required check in branch protection to enforce on merge.