### PR TITLE
Prepare release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.0.2 (July 9, 2026)
+SECURITY:
+
+* Update the Consul Build Go base image to `alpine3.24` [[GH-1181](https://github.com/hashicorp/consul-dataplane/pull/1181)]
+
+IMPROVEMENTS:
+
+* Update Envoy version to 1.38.3 [[GH-1185](https://github.com/hashicorp/consul-dataplane/pull/1185)]
+
 ## 2.0.0 (May 23, 2026)
 
 SECURITY:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,12 +17,12 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "2.0.0"
+	Version = "2.0.2"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Automated release preparation for consul-dataplane 2.0.2.

Generated by `release-scripts/prepare-release-branch.sh`:
- Bumped `pkg/version/version.go` to 2.0.2 (`make prepare-release`).
- Prepended the 2.0.2 CHANGELOG entry (`make changelog`, since v2.0.1).

Base branch `release/2.0.2` was cut from `release/2.0.x`.