### PR TITLE
Prepare release 1.8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.8.15 (July 9, 2026)
+SECURITY:
+
+* Update the Consul Build Go base image to `alpine3.24` [[GH-1181](https://github.com/hashicorp/consul-dataplane/pull/1181)]
+
+IMPROVEMENTS:
+
+* Update Envoy version to 1.38.3 [[GH-1185](https://github.com/hashicorp/consul-dataplane/pull/1185)]
+
+BUG FIXES:
+
+* - envoy: add `skip_exit` to `drain_listeners` admin API call to prevent premature pod termination when upgrading to Envoy 1.37+ [[GH-1064](https://github.com/hashicorp/consul-dataplane/pull/1064)]
+* - envoy: prevent graceful shutdown errors from closing errorExitCh, which caused Envoy to be killed immediately bypassing the configured grace period [[GH-1072](https://github.com/hashicorp/consul-dataplane/pull/1072)]
+
 ## 1.8.13 (May 23, 2026)
 SECURITY:
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,12 +17,12 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.8.0"
+	Version = "1.8.15"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Automated release preparation for consul-dataplane 1.8.15.

Generated by `release-scripts/prepare-release-branch.sh`:
- Bumped `pkg/version/version.go` to 1.8.15 (`make prepare-release`).
- Prepended the 1.8.15 CHANGELOG entry (`make changelog`, since v1.8.14).

Base branch `release/1.8.15` was cut from `release/1.8.x`.