### PR TITLE
Increase stale PR windows to 90/60 days

### DIFF
--- a/.changelog/1197.txt
+++ b/.changelog/1197.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ci: Increased the stale PR automation windows to 90 days before marking a pull request stale and 60 days before closing it.
+```

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           days-before-stale: -1
           days-before-close: -1

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,31 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: stale prs
+on:
+  schedule:
+    - cron: 0 1 * * *
+  workflow_dispatch: {}
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-pr-stale: 90
+          days-before-pr-close: 60
+          stale-pr-message: This pull request has been automatically flagged
+            for inactivity because it has not been acted upon in the last 90
+            days. It will be closed if no new activity occurs in the next
+            60 days. Please feel free to re-open to resurrect the change if
+            you feel this has happened by mistake. Thank you for your
+            contributions.
+          close-pr-message: Closing due to inactivity. If you feel this was a
+            mistake or you wish to re-open at any time in the future, please
+            leave a comment and it will be re-surfaced for the maintainers to review.
+          stale-pr-label: meta/stale
+          exempt-pr-labels: meta/staleproof


### PR DESCRIPTION
### Description

The stale PR automation was closing pull requests too aggressively (60 days to stale, 30 days to close). 

###Fix

- Added a new workflow (with matching 90/60 settings) to the repo that were missing to reflect the new 90/60 day windows.