### PR TITLE
s390x support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - main
       - release/**
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           - {goos: "linux", goarch: "arm64", gotags: "hashicorpmetrics"}
           - {goos: "linux", goarch: "386", gotags: "hashicorpmetrics"}
           - {goos: "linux", goarch: "amd64", gotags: "hashicorpmetrics"}
+          - {goos: "linux", goarch: "s390x", gotags: "hashicorpmetrics"}
           - {goos: "linux", goarch: "amd64", gotags: "hashicorpmetrics,fips", env: "CGO_ENABLED=1 GOEXPERIMENT=boringcrypto", fips: "+fips1402", pkg_suffix: "-fips" }
           - {goos: "linux", goarch: "arm64", gotags: "hashicorpmetrics,fips", env: "CGO_ENABLED=1 GOEXPERIMENT=boringcrypto CC=aarch64-linux-gnu-gcc", fips: "+fips1402", pkg_suffix: "-fips" }
           - {goos: "darwin", goarch: "amd64", gotags: "hashicorpmetrics"}
@@ -165,6 +166,7 @@ jobs:
           - { arch: "amd64", fips: "+fips1402" }
           - { arch: "arm64" }
           - { arch: "arm64", fips: "+fips1402" }
+          - { arch: "s390x" }
     env:
       repo: ${{ github.event.repository.name }}
       version: ${{ needs.get-product-version.outputs.product-version }}${{ matrix.fips }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
       - main
       - release/**
   pull_request:
+      branches:
+      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,12 @@ jobs:
       version: ${{needs.get-product-version.outputs.product-version}}${{ matrix.fips }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
@@ -283,6 +289,12 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # This naming convention will be used ONLY for per-commit dev images
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set docker dev tag
         run: |
           echo "full_dev_tag=${{ env.version }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,6 @@ on:
     branches:
       - main
       - release/**
-  pull_request:
-      branches:
-      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,12 +175,18 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # This naming convention will be used ONLY for per-commit dev images
       - name: Set docker dev tag
         run: |
           echo "full_dev_tag=${{ env.version }}"
           echo "full_dev_tag=${{ env.version }}" >> $GITHUB_ENV
-          echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" 
+          echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')"
           echo "minor_dev_tag=$(echo ${{ env.version }}| sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+(-[0-9a-zA-Z\+\.]+)?$/\1\2/')" >> $GITHUB_ENV
 
       - name: Docker Build (Action)

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -53,6 +53,11 @@ jobs:
       - get-go-version
     runs-on: ubuntu-latest
     steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-ARG ENVOY_VERSION=1.37.2
-FROM hashicorppreview/envoy-dev:1.37.2-latest AS envoy-binary
+ARG ENVOY_VERSION=1.38.3
+FROM hashicorppreview/envoy-dev:${ENVOY_VERSION} AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM ubuntu:22.04 AS setcap-envoy-binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG ENVOY_VERSION=1.37.2
 FROM hashicorppreview/envoy-dev:1.37.2-latest AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
-FROM debian:bookworm-slim AS setcap-envoy-binary
+FROM ubuntu:22.04 AS setcap-envoy-binary
 
 ARG BIN_NAME=consul-dataplane
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-ARG ENVOY_VERSION=1.37.1
+ARG ENVOY_VERSION=1.37.2
 FROM hashicorppreview/envoy-dev:${ENVOY_VERSION}-latest AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-ARG ENVOY_VERSION=1.38.3
+ARG ENVOY_VERSION=1.37.2
 FROM hashicorp/envoy:${ENVOY_VERSION} AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-ARG ENVOY_VERSION=1.37.2
+ARG ENVOY_VERSION=1.37.2-latest
 FROM hashicorppreview/envoy-dev:${ENVOY_VERSION} AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #
 ARG GOLANG_VERSION
 ARG ENVOY_VERSION=1.37.2
-FROM hashicorp/envoy:${ENVOY_VERSION} AS envoy-binary
+FROM hashicorppreview/envoy-dev:${ENVOY_VERSION} AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bookworm-slim AS setcap-envoy-binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-ARG ENVOY_VERSION=1.38.3
-FROM hashicorppreview/envoy-dev:${ENVOY_VERSION} AS envoy-binary
+ARG ENVOY_VERSION=1.37.1
+FROM hashicorppreview/envoy-dev:${ENVOY_VERSION}-latest AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM ubuntu:22.04 AS setcap-envoy-binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@
 # prebuilt binaries in any other form.
 #
 ARG GOLANG_VERSION
-ARG ENVOY_VERSION=1.37.2-latest
-FROM hashicorppreview/envoy-dev:${ENVOY_VERSION} AS envoy-binary
+ARG ENVOY_VERSION=1.37.2
+FROM hashicorppreview/envoy-dev:1.37.2-latest AS envoy-binary
 
 # Modify the envoy binary to be able to bind to privileged ports (< 1024).
 FROM debian:bookworm-slim AS setcap-envoy-binary


### PR DESCRIPTION
Enabling s390x arch build support.(fips, ubi, redhat is not covered)

**New generated builds are not tested due to lack of IBM Z infra. Once its merged to main and images is available in docker, testing will be performed.**

**This changes are for testing not for release**
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
