### PR TITLE
nft migration

### DIFF
--- a/integration-tests/helpers/pod.go
+++ b/integration-tests/helpers/pod.go
@@ -43,10 +43,10 @@ func RunPod(t *testing.T, suite *Suite, podName string, mappedPorts []nat.Port) 
 	}
 }
 
-// ExposeInternalPorts creates iptables rules to forward traffic from
+// ExposeInternalPorts creates nftables rules to forward traffic from
 // public-facing ports to those bound only on the loopback interface. This
 // is useful for testing our DNS proxy which can **only** be bound to the
-// loopback interace.
+// loopback interface.
 func (p *Pod) ExposeInternalPorts(t *testing.T, ports []nat.Port) {
 	t.Helper()
 
@@ -59,12 +59,14 @@ func (p *Pod) ExposeInternalPorts(t *testing.T, ports []nat.Port) {
 
 	cmds := []string{
 		"sysctl -w net.ipv4.conf.all.route_localnet=1",
-		"apk add iptables",
+		"apk add nftables",
+		"nft add table ip nat",
+		"nft add chain ip nat prerouting { type nat hook prerouting priority -100 ; }",
 	}
 
 	for _, port := range ports {
 		cmds = append(cmds, fmt.Sprintf(
-			"iptables -t nat -A PREROUTING -p %s --dport %s -j DNAT --to-destination 127.0.0.1:%s",
+			"nft add rule ip nat prerouting %s dport %s dnat to 127.0.0.1:%s",
 			port.Proto(),
 			port.Port(),
 			port.Port(),


### PR DESCRIPTION
## Description

Migrates the integration test helper in consul-dataplane from `iptables` to `nftables` rules.

### Why

Part of the broader iptables → nftables migration across the Consul service mesh stack. The integration test helper `ExposeInternalPorts` was installing and using `iptables` directly inside test containers; this updates it to use `nftables` instead.

### What changed

**`integration-tests/helpers/pod.go`**
- Updated `ExposeInternalPorts` doc comment: `iptables` → `nftables`; fixed typo `interace` → `interface`
- Replaced `apk add iptables` with `apk add nftables`
- Added `nft add table ip nat` and `nft add chain ip nat prerouting` setup commands before the per-port rules
- Replaced the iptables `PREROUTING DNAT` rule with the equivalent `nft add rule` command

### Related PRs

- consul (SDK + core): https://github.com/hashicorp/consul/pull/23785
- consul-k8s (control plane + CNI): https://github.com/hashicorp/consul-k8s/pull/5554

### Testing

- Integration test helper updated to use nftables commands
- No logic change — same port forwarding behaviour, different rule engine