### PR TITLE
Backport Skip checks when changes are in ./release/** files 2.0.x  (#1204)

### DIFF
--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -11,10 +11,37 @@ jobs:
   conditional-skip:
     uses: ./.github/workflows/reusable-conditional-skip.yml
 
+  # Detect PRs whose changes are limited to the .release/ directory (CRT release
+  # orchestration). These files don't affect tests or coverage, so we skip all
+  # check jobs for them. Scoped to pull_request events only — on push to main/
+  # release/** this output is ignored and checks always run.
+  check-release-only:
+    runs-on: ubuntu-latest
+    name: Check whether only .release files changed
+    outputs:
+      release-only: ${{ steps.changed-files.outputs.only_changed }}
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+      - name: Check for changes outside .release
+        id: changed-files
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
+        with:
+          files: |
+            .release/**
+
   get-go-version:
-    # Cascades down to test jobs
-    needs: [conditional-skip]
-    if: needs.conditional-skip.outputs.skip-ci != 'true'
+    # Cascades down to test jobs.
+    # Skipped when: (a) only skippable files changed (skip-ci), or
+    #               (b) this is a PR touching only .release/** files (release-only).
+    # On push to main/release/** the release-only condition is never true so
+    # checks always run on protected branches.
+    needs: [conditional-skip, check-release-only]
+    if: >-
+      needs.conditional-skip.outputs.skip-ci != 'true' &&
+      !(github.event_name == 'pull_request' &&
+        needs.check-release-only.outputs.release-only == 'true')
     uses: ./.github/workflows/reusable-get-go-version.yml
 
   unit-tests:
@@ -59,3 +86,37 @@ jobs:
         with:
           version: "v2.11.4"
           args: --build-tags hashicorpmetrics
+
+  pass-required-checks-on-skip:
+    needs: [ conditional-skip, check-release-only ]
+    # Fire only on pull_request events when CI is skipped (skip-ci) or when the
+    # PR only touched .release/** files. The pull_request guard ensures this
+    # never fires on push-to-main, where checks must always run.
+    # always() ensures this job is not skipped even if check-release-only fails.
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      (needs.conditional-skip.outputs.skip-ci == 'true' ||
+      needs.check-release-only.outputs.release-only == 'true')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Required checks that must be marked success when CI is skipped
+          - check-name: unit-tests
+          - check-name: integration-tests
+          - check-name: lint
+          - check-name: integration-tests-success
+    steps:
+    - name: Update final status
+      uses: docker://ghcr.io/curtbushko/commit-status-action:e1d661c757934ab35c74210b4b70c44099ec747a
+      env:
+        INPUT_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        INPUT_REPOSITORY: ${{ github.repository }}
+        INPUT_CONTEXT: ${{ matrix.check-name }}
+        INPUT_STATE: success
+        INPUT_DESCRIPTION: "Skipped due to .release-only changes"
+        INPUT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        INPUT_DETAILS_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        INPUT_OWNER: "hashicorp"
+


### PR DESCRIPTION
* Mnaual backoport for https://github.com/hashicorp/consul-dataplane/pull/1204