### PR TITLE
CVE suppress and Dockerfile update

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -27,7 +27,7 @@ container {
   triage {
     suppress {
       vulnerabilities = [
- 
+      
       ]
       paths = [
         // The OSV scanner will trip on several packages that are included in the
@@ -63,7 +63,10 @@ repository {
 
   triage {
     suppress {
-      vulnerabilities = []
+      vulnerabilities = [
+      "GO-2026-5856",
+      "GO-2026-4970",
+      ]
       paths = [
         # SHA1 usage in bootstrap config is for non-security purposes
         "internal/bootstrap/bootstrap_config.go"

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -24,6 +24,8 @@ container {
 
   # Triage items that are _safe_ to ignore here. Note that this list should be
   # periodically cleaned up to remove items that are no longer found by the scanner.
+  # suppressed crypto related CVE in containers and
+  # Even though GO-2026-5856 and GO-2026-4970 CVE are fixed in go 1.26.5, the prepare workflow scan binaries are failing.
   triage {
     suppress {
       vulnerabilities = [

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -30,7 +30,7 @@ container {
     suppress {
       vulnerabilities = [
       "GO-2026-5856",
-      "GO-2026-5932"
+      "GO-2026-5932",
       ]
       paths = [
         // The OSV scanner will trip on several packages that are included in the

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -27,7 +27,7 @@ container {
   triage {
     suppress {
       vulnerabilities = [
-      
+      "GO-2026-5856",
       ]
       paths = [
         // The OSV scanner will trip on several packages that are included in the

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -30,6 +30,7 @@ container {
     suppress {
       vulnerabilities = [
       "GO-2026-5856",
+      "GO-2026-5932"
       ]
       paths = [
         // The OSV scanner will trip on several packages that are included in the

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN git clone https://github.com/hashicorp/go-discover.git /src/go-discover && \
     git checkout ca13b81fe744b323d3730020a898a288ce502069 && \
     go get golang.org/x/net@v0.57.0 && \
     go get golang.org/x/crypto@v0.54.0 && \
-    go get google.golang.org/grpc@v1.83.1 && \
+    go get google.golang.org/grpc@v1.83.0 && \
     go get go.opentelemetry.io/otel@v1.44.0 && \
     go mod tidy && \
     CGO_ENABLED=0 go build -o /go/bin/discover ./cmd/discover

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ RUN git clone https://github.com/hashicorp/go-discover.git /src/go-discover && \
     git checkout ca13b81fe744b323d3730020a898a288ce502069 && \
     go get golang.org/x/net@v0.55.0 && \
     go get golang.org/x/crypto@v0.52.0 && \
+    go get google.golang.org/grpc@v1.83.1 && \
+    go get go.opentelemetry.io/otel@v1.44.0 && \
     go mod tidy && \
     CGO_ENABLED=0 go build -o /go/bin/discover ./cmd/discover
 


### PR DESCRIPTION
Even though GO-2026-5856 and GO-2026-4970 CVE are fixed in go 1.26.5, the prepare workflow scan binaries are failing.
Post confirmation with security team, decision is taken to suppress these security vulnerabilities.
The otel dependency is hit from the go-discover container and are causing CVEs -https://github.com/hashicorp/crt-workflows-common/actions/runs/31375198292/job/93415611833  and updated it in dockerfile.
