### PR TITLE
Backport of CVE suppress and Dockerfile update into release/1.9.x

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -27,6 +27,8 @@ container {
   triage {
     suppress {
       vulnerabilities = [
+      "GO-2026-5856",
+      "GO-2026-5932",
       ]
       paths = [
         // The OSV scanner will trip on several packages that are included in the
@@ -62,7 +64,10 @@ repository {
 
   triage {
     suppress {
-      vulnerabilities = []
+      vulnerabilities = [
+      "GO-2026-5856",
+      "GO-2026-4970",
+      ]
       paths = [
         # SHA1 usage in bootstrap config is for non-security purposes
         "internal/bootstrap/bootstrap_config.go"

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,10 @@ RUN apk add --no-cache git
 RUN git clone https://github.com/hashicorp/go-discover.git /src/go-discover && \
     cd /src/go-discover && \
     git checkout ca13b81fe744b323d3730020a898a288ce502069 && \
-    go get golang.org/x/net@v0.55.0 && \
-    go get golang.org/x/crypto@v0.52.0 && \
+    go get golang.org/x/net@v0.57.0 && \
+    go get golang.org/x/crypto@v0.54.0 && \
+    go get google.golang.org/grpc@v1.83.0 && \
+    go get go.opentelemetry.io/otel@v1.44.0 && \
     go mod tidy && \
     CGO_ENABLED=0 go build -o /go/bin/discover ./cmd/discover
 


### PR DESCRIPTION
* Manual backport from https://github.com/hashicorp/consul-dataplane/pull/1233 to be assessed for backporting due to the inclusion of the label backport/1.9.

---

**Note:** This PR also covers the equivalent changes originally introduced in #1235 ("dockerfile update" — bumping `golang.org/x/net` and `golang.org/x/crypto` versions in the go-discover Dockerfile build stage). #1233 and #1235 were merged into `main` in quick succession, and #1235's changes were already part of `main` by the time #1233 was backported here, so this PR's diff against `release/1.9.x` includes both. Referencing #1235 here so it is correctly tracked as backported to `release/1.9.x`.
