### PR TITLE
Prepare release 1.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.8.16 (August 10, 2026)
+
+SECURITY:
+
+* Upgrade dependencies to address CVE findings:Upgraded `golang.org/x/text` to 0.40.0 , `google.golang.org/grpc` to 1.82.1 and `go.opentelemetry.io/otel` to 1.44.0 fixes CVEs GO-2026-5970 ,GO-2026-6061 ,GO-2026-5158 respectively [[GH-1228](https://github.com/hashicorp/consul-dataplane/pull/1228),[GH-1210](https://github.com/hashicorp/consul-dataplane/pull/1210),[GH-1235](https://github.com/hashicorp/consul-dataplane/pull/1235)]
+
 IMPROVEMENTS:
 
 * Upgrade to use Go 1.26.5. [[GH-1206](https://github.com/hashicorp/consul-dataplane/pull/1206)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.8.16 (August 10, 2026)
+IMPROVEMENTS:
+
+* Upgrade to use Go 1.26.5. [[GH-1206](https://github.com/hashicorp/consul-dataplane/pull/1206)]
+
+BUG FIXES:
+
+* dns: Remove noisy debug log emitted on benign read timeouts in the UDP proxy loop. [[GH-1198](https://github.com/hashicorp/consul-dataplane/pull/1198)]
+
 ## 1.8.13 (May 23, 2026)
 SECURITY:
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,12 +17,12 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.8.0"
+	Version = "1.8.16"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Automated release preparation for consul-dataplane 1.8.16.

Generated by `release-scripts/prepare-release-branch.sh`:
- Bumped `pkg/version/version.go` to 1.8.16 (`make prepare-release`).
- Prepended the 1.8.16 CHANGELOG entry (`make changelog`, since v1.8.15).

Base branch `release/1.8.16` was cut from `release/1.8.x`.