### PR TITLE
ci: gate PR merges on per-package coverage regression

### DIFF
--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -81,7 +81,7 @@ jobs:
     # Patch coverage measures the lines a PR adds/modifies, so it only applies
     # to pull requests. Pushes to main run coverage-report for the badge but
     # have no "patch" to evaluate. Only gate when the report succeeded.
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success' }}
+    if: "!cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success'"
     runs-on: ubuntu-latest
     env:
       # Minimum required coverage of the lines a PR adds/modifies (patch
@@ -143,6 +143,111 @@ jobs:
               echo "The lines this PR adds or modifies are not sufficiently covered by tests."
               echo "Add tests for the new/changed code, or adjust \`PATCH_THRESHOLD\` in \`.github/workflows/consul-dataplane-checks.yaml\` (with reviewer sign-off)."
             } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+  coverage-regression-gate:
+    name: coverage-regression-gate
+    needs: [coverage-report]
+    # Only runs on PRs — a push to main has no baseline to regress against
+    # (it IS the new baseline). Only gate when the report succeeded.
+    if: "!cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Download pkg-summary artifact
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: pkg-summary
+          path: .
+
+      - name: Enforce per-package coverage regression gate
+        env:
+          TOTAL: ${{ needs.coverage-report.outputs.total }}
+        run: |
+          set -euo pipefail
+
+          # If no coverage profiles were produced (e.g. only non-Go files
+          # changed), there is nothing to compare — pass.
+          if [ "${TOTAL:-N/A}" = "N/A" ]; then
+            echo "::notice::No coverage data produced; regression gate skipped."
+            {
+              echo "### ✅ Coverage regression gate passed"
+              echo ""
+              echo "No coverage data was produced (no coverable Go files), so there is nothing to compare."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # If no baseline file exists yet (first run after this feature merges),
+          # skip gracefully — the next push to main will create it.
+          if [ ! -f ".github/coverage-baseline.txt" ]; then
+            echo "::notice::No coverage baseline found (.github/coverage-baseline.txt). Skipping regression check."
+            {
+              echo "### ✅ Coverage regression gate passed"
+              echo ""
+              echo "No coverage baseline file found. The baseline will be created on the next merge to \`main\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          BASELINE=".github/coverage-baseline.txt"
+          PR_SUMMARY="pkg-summary.txt"
+
+          FAILED=0
+          TABLE_ROWS=""
+
+          # For every package in the PR summary, check if its average dropped
+          # below the stored baseline value. Packages not in the baseline (new
+          # packages) are skipped — they have no prior coverage to regress from.
+          while IFS= read -r line; do
+            pkg=$(echo "$line" | awk '{print $1}')
+            pr_pct=$(echo "$line" | awk '{print $2}' | tr -d '%')
+
+            # Look up this package in the baseline.
+            base_line=$(grep "^${pkg} " "$BASELINE" || true)
+            if [ -z "$base_line" ]; then
+              # New package — no baseline to compare against, pass.
+              TABLE_ROWS="${TABLE_ROWS}| \`${pkg}\` | N/A (new) | ${pr_pct}% | — | ✅ new package |\n"
+              continue
+            fi
+
+            base_pct=$(echo "$base_line" | awk '{print $2}' | tr -d '%')
+
+            # Compare: fail if PR average is strictly less than baseline.
+            if awk "BEGIN { exit !(${pr_pct} < ${base_pct}) }"; then
+              delta=$(awk "BEGIN { printf \"%.1f\", ${pr_pct} - ${base_pct} }")
+              TABLE_ROWS="${TABLE_ROWS}| \`${pkg}\` | ${base_pct}% | ${pr_pct}% | ${delta}% | ❌ REGRESSED |\n"
+              echo "::error::Package '${pkg}' coverage dropped from ${base_pct}% to ${pr_pct}% (${delta}%)"
+              FAILED=1
+            else
+              delta=$(awk "BEGIN { printf \"%.1f\", ${pr_pct} - ${base_pct} }")
+              prefix=""
+              [ "$(awk "BEGIN{print (${delta}>0)}")" = "1" ] && prefix="+"
+              TABLE_ROWS="${TABLE_ROWS}| \`${pkg}\` | ${base_pct}% | ${pr_pct}% | ${prefix}${delta}% | ✅ OK |\n"
+            fi
+          done < "$PR_SUMMARY"
+
+          # Write the full table to the step summary regardless of pass/fail.
+          {
+            if [ "$FAILED" -eq 1 ]; then
+              echo "### ❌ Coverage regression gate failed"
+              echo ""
+              echo "One or more packages have lower average coverage than the \`main\` baseline."
+              echo "Add or restore tests to bring these packages back to or above their baseline coverage."
+            else
+              echo "### ✅ Coverage regression gate passed"
+              echo ""
+              echo "All packages maintain or improve their coverage compared to the \`main\` baseline."
+            fi
+            echo ""
+            echo "| Package | Baseline | PR | Delta | Status |"
+            echo "|---------|----------|----|-------|--------|"
+            printf "%b" "$TABLE_ROWS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$FAILED" -eq 1 ]; then
             exit 1
           fi
 
@@ -214,4 +319,3 @@ jobs:
         INPUT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         INPUT_DETAILS_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         INPUT_OWNER: "hashicorp"
-

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -121,6 +121,45 @@ jobs:
 
           go tool cover -html=merged-coverage.out -o coverage.html
 
+      - name: Upload pkg-summary artifact
+        # Upload pkg-summary.txt so the regression gate job can download it.
+        # Must run before the "Update coverage badge" step to ensure the file
+        # exists as an artifact regardless of badge push outcome.
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: pkg-summary
+          path: pkg-summary.txt
+          if-no-files-found: ignore
+
+      - name: Commit coverage baseline to main
+        # On every merge to main, commit the updated pkg-summary.txt as the
+        # authoritative per-package baseline for the regression gate.
+        # PRs compare their per-package averages against this file to detect
+        # regressions before they can be merged.
+        if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          # Pull latest main to avoid conflicts with concurrent badge commits.
+          git fetch origin main --depth=1
+          git pull --ff-only origin main
+
+          mkdir -p .github
+          cp pkg-summary.txt .github/coverage-baseline.txt
+          git add .github/coverage-baseline.txt
+          if git diff --staged --quiet; then
+            echo "Coverage baseline unchanged, skipping commit"
+          else
+            git commit -m "ci: update coverage baseline [skip ci]"
+            git push origin HEAD:main
+          fi
+
       - name: Compute patch coverage
         id: patch
         if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'


### PR DESCRIPTION
## Summary

Adds a **per-package coverage regression gate** to consul-dataplane, ensuring no PR can lower the average test coverage of any package below its current baseline on `main`.

This complements the existing 90% patch coverage gate (merged in #1178) — patch coverage asks *"are your new lines tested?"*, this gate asks *"did the overall package health go down?"*

## How it works

1. On every merge to `main`, `reusable-coverage-report.yml` commits the per-package coverage averages to `.github/coverage-baseline.txt` (the authoritative baseline).
2. On every PR, the new `coverage-regression-gate` job downloads the per-package summary artifact, compares each package against the baseline, and **fails if any package average dropped**.
3. New packages (no prior baseline) are always allowed through.
4. On the first PR after this merges the gate skips gracefully — no baseline exists yet. The baseline is created on the next push to `main`.

## Changes

- **`reusable-coverage-report.yml`**:
  - Upload `pkg-summary` artifact so the regression gate job can consume it
  - On merges to `main`, commit `pkg-summary.txt` as `.github/coverage-baseline.txt`
  - Fix `coverage-gate` `if:` expression (remove erroneous `${{ }}` wrapper on job-level condition)

- **`consul-dataplane-checks.yaml`**:
  - Add `coverage-regression-gate` job that enforces per-package coverage does not regress

## Notes

- Single module repo (`github.com/hashicorp/consul-dataplane`) — no multi-module complexity
- Mocks excluded (`/mocks/`, `/mock_`) consistent with existing coverage filtering
- Make `coverage-regression-gate` a required branch-protection check to enforce on merge