### PR TITLE
bug: exit consul-dataplane when Envoy version is rejected by Consul server

### DIFF
--- a/.changelog/1252.txt
+++ b/.changelog/1252.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed consul-dataplane looping forever when the Consul server rejects the connected Envoy version as unsupported. consul-dataplane now exits immediately with a clear error message and a non-zero exit code, unblocking rolling deployments in ECS and Kubernetes environments.
+```

--- a/pkg/consuldp/consul_dataplane.go
+++ b/pkg/consuldp/consul_dataplane.go
@@ -10,7 +10,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/go-metrics"
 	"github.com/hashicorp/consul-server-connection-manager/discovery"
@@ -29,7 +31,8 @@ type xdsServer struct {
 	listenerAddress string
 	listenerNetwork string
 	gRPCServer      *grpc.Server
-	exitedCh        chan struct{}
+	exitedCh   chan struct{}
+	closeOnce sync.Once
 }
 
 type httpClient interface {
@@ -336,14 +339,19 @@ func (cdp *ConsulDataplane) envoyProxyConfig(cfg []byte) envoy.ProxyConfig {
 		extraArgs = append(extraArgs, fmt.Sprintf("%s %v", envoyArg, cdpEnvoyValue))
 	}
 
+	// Wrap os.Stderr so that the fatal "Envoy version too old" message emitted
+	// by Envoy triggers an immediate consul-dataplane shutdown. This is the most
+	// reliable detection point because the message always appears in Envoy's
+	// stderr output regardless of how the gRPC transport surfaces the trailer.
 	return envoy.ProxyConfig{
-		AdminAddr:       cdp.cfg.Envoy.AdminBindAddress,
-		AdminBindPort:   cdp.cfg.Envoy.AdminBindPort,
-		Logger:          cdp.logger,
-		LogJSON:         cdp.cfg.Logging.LogJSON,
-		BootstrapConfig: cfg,
-		ExecutablePath:  cdp.cfg.Envoy.ExecutablePath,
-		ExtraArgs:       extraArgs,
+		AdminAddr:        cdp.cfg.Envoy.AdminBindAddress,
+		AdminBindPort:    cdp.cfg.Envoy.AdminBindPort,
+		Logger:           cdp.logger,
+		LogJSON:          cdp.cfg.Logging.LogJSON,
+		BootstrapConfig:  cfg,
+		ExecutablePath:   cdp.cfg.Envoy.ExecutablePath,
+		ExtraArgs:        extraArgs,
+		EnvoyErrorStream: cdp.newEnvoyLogScanner(os.Stderr),
 	}
 }
 

--- a/pkg/consuldp/xds.go
+++ b/pkg/consuldp/xds.go
@@ -5,6 +5,7 @@ package consuldp
 
 import (
 	"context"
+	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -21,6 +22,12 @@ const (
 	metadataKeyToken   = "x-consul-token"
 	envoyADSMethodName = "envoy.service.discovery.v3.AggregatedDiscoveryService/DeltaAggregatedResources"
 	maxRecvSize        = 50 * 1024 * 1024
+
+	// envoyVersionUnsupportedMsg is the substring that Consul server includes in the
+	// gRPC status message when it rejects an Envoy version that is too old.  This is
+	// a permanent, non-retriable condition so consul-dataplane must treat it as fatal
+	// and exit rather than keeping the (zombie) process alive indefinitely.
+	envoyVersionUnsupportedMsg = "is too old and is not supported by Consul"
 )
 
 // director is the helper called by the unknown service gRPC handler. This helper is responsible for injecting the ACL token
@@ -103,7 +110,7 @@ func (cdp *ConsulDataplane) startXDSServer(ctx context.Context) {
 
 	if err := cdp.xdsServer.gRPCServer.Serve(cdp.xdsServer.listener); err != nil {
 		cdp.logger.Error("failed to serve xDS requests", "error", err)
-		close(cdp.xdsServer.exitedCh)
+		cdp.xdsServer.closeExitedCh()
 	}
 }
 
@@ -116,10 +123,53 @@ func (cdp *ConsulDataplane) stopXDSServer() {
 
 func (cdp *ConsulDataplane) xdsServerExited() chan struct{} { return cdp.xdsServer.exitedCh }
 
+// streamInterceptor returns a gRPC stream server interceptor that tracks
+// the envoy_connected metric via metricServerStream.
 func (cdp *ConsulDataplane) streamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		return handler(srv, &metricServerStream{ss})
 	}
+}
+
+// newEnvoyLogScanner wraps an io.Writer (typically os.Stderr) and scans each
+// write for the Consul server's permanent "Envoy version too old" rejection
+// message. When detected it triggers a fatal shutdown via closeExitedCh so
+// that consul-dataplane exits with a non-zero code instead of looping forever.
+//
+// Envoy emits this line on its stderr stream exactly as shown in the log:
+//
+//	DeltaAggregatedResources gRPC config stream to consul-dataplane closed: 3,
+//	Envoy X.Y.Z is too old and is not supported by Consul
+//
+// We match on the substring rather than the full line so that version numbers
+// and surrounding text do not affect detection.
+func (cdp *ConsulDataplane) newEnvoyLogScanner(underlying io.Writer) io.Writer {
+	return &envoyLogScanner{
+		Writer: underlying,
+		cdp:    cdp,
+	}
+}
+
+type envoyLogScanner struct {
+	io.Writer
+	cdp     *ConsulDataplane
+}
+
+// Write forwards every byte to the underlying writer and checks for the fatal
+// version-rejection message. Safe to call from multiple goroutines because
+// closeExitedCh uses sync.Once internally.
+func (s *envoyLogScanner) Write(p []byte) (int, error) {
+	n, err := s.Writer.Write(p)
+	if strings.Contains(string(p), envoyVersionUnsupportedMsg) {
+		s.cdp.logger.Error(
+			"Envoy version is not supported by Consul server — this is a permanent error, " +
+				"consul-dataplane will now exit. Please upgrade Envoy to a supported version.",
+		)
+		if s.cdp.xdsServer != nil {
+			s.cdp.xdsServer.closeExitedCh()
+		}
+	}
+	return n, err
 }
 
 type metricServerStream struct {
@@ -144,4 +194,10 @@ func (s *metricServerStream) RecvMsg(m interface{}) error {
 	}
 	metrics.SetGauge([]string{"envoy_connected"}, 0)
 	return err
+}
+
+// closeExitedCh closes exitedCh exactly once, regardless of how many concurrent
+// streams may detect the same fatal condition.
+func (x *xdsServer) closeExitedCh() {
+	x.closeOnce.Do(func() { close(x.exitedCh) })
 }

--- a/pkg/consuldp/xds_test.go
+++ b/pkg/consuldp/xds_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+	"io"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -142,4 +144,87 @@ func TestSetupXDSServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEnvoyLogScannerFatalExit verifies that the envoyLogScanner writer closes
+// xdsServer.exitedCh when it sees the "Envoy version too old" rejection message
+// in Envoy's stderr output — the canonical detection point for this fatal error.
+func TestEnvoyLogScannerFatalExit(t *testing.T) {
+	type testCase struct {
+		name        string
+		logLine     string
+		expectClose bool
+	}
+
+	testCases := []testCase{
+		{
+			name:        "exact rejection message",
+			logLine:     "[warning] envoy.config(20) DeltaAggregatedResources gRPC config stream to consul-dataplane closed: 3, Envoy 1.33.6 is too old and is not supported by Consul",
+			expectClose: true,
+		},
+		{
+			name:        "different envoy version in message",
+			logLine:     "Envoy 1.29.0 is too old and is not supported by Consul",
+			expectClose: true,
+		},
+		{
+			name:        "unrelated log line",
+			logLine:     "[info] envoy.main(20) starting main dispatch loop",
+			expectClose: false,
+		},
+		{
+			name:        "empty log line",
+			logLine:     "",
+			expectClose: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cdp := &ConsulDataplane{
+				cfg:    &Config{XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: 0}},
+				logger: hclog.NewNullLogger(),
+			}
+			require.NoError(t, cdp.setupXDSServer())
+
+			scanner := cdp.newEnvoyLogScanner(io.Discard)
+			_, err := scanner.Write([]byte(tc.logLine))
+			require.NoError(t, err)
+
+			if tc.expectClose {
+				select {
+				case <-cdp.xdsServer.exitedCh:
+					// expected
+				case <-time.After(time.Second):
+					t.Fatal("exitedCh was not closed after fatal Envoy log message")
+				}
+			} else {
+				select {
+				case <-cdp.xdsServer.exitedCh:
+					t.Fatal("exitedCh was unexpectedly closed for a non-fatal log message")
+				case <-time.After(200 * time.Millisecond):
+					// expected: channel still open
+				}
+			}
+		})
+	}
+}
+
+// TestEnvoyLogScannerCloseOnce verifies that multiple writes containing the fatal
+// message do not panic from a double-close of exitedCh.
+func TestEnvoyLogScannerCloseOnce(t *testing.T) {
+	cdp := &ConsulDataplane{
+		cfg:    &Config{XDSServer: &XDSServer{BindAddress: "127.0.0.1", BindPort: 0}},
+		logger: hclog.NewNullLogger(),
+	}
+	require.NoError(t, cdp.setupXDSServer())
+
+	scanner := cdp.newEnvoyLogScanner(io.Discard)
+	fatalMsg := []byte("Envoy 1.33.6 is too old and is not supported by Consul")
+
+	require.NotPanics(t, func() {
+		for i := 0; i < 5; i++ {
+			_, _ = scanner.Write(fatalMsg)
+		}
+	})
 }


### PR DESCRIPTION
## Problem

When the Consul server closes the ADS gRPC stream because the connected Envoy version is too old, `consul-dataplane` previously kept running indefinitely. This is a **permanent, non-retriable condition** — no amount of retrying will allow the process to serve traffic.

The zombie container blocks rolling deployments in orchestrated environments (ECS, Kubernetes) because the orchestrator treats the task/pod as healthy since the process is still running, and new tasks wait for the old ones to drain.

Example Envoy log line emitted when this happens:

```
[warning] envoy.config(44) DeltaAggregatedResources gRPC config stream to consul-dataplane closed: 3, Envoy 1.33.6 is too old and is not supported by Consul
```

Related upstream issue: https://github.com/hashicorp/consul-dataplane/issues/1245

## Root Cause Analysis

The Consul server closes the ADS stream using **HTTP/2 trailers** (`grpc-status: 3 UNAVAILABLE`, `grpc-message: Envoy X.Y.Z is too old and is not supported by Consul`). The `grpc-proxy` transparent handler forwards those trailers to the Envoy-facing side and returns `io.EOF` — not a gRPC status error — to the stream interceptor chain. This means a `StreamServerInterceptor` cannot observe the rejection as an actionable error value.

Envoy itself **always** logs the full rejection message to its stderr stream (`cmd.Stderr = p.cfg.EnvoyErrorStream` in `pkg/envoy/proxy.go`). This is the reliable, version-agnostic interception point.

## Fix

Added an `envoyLogScanner` — a lightweight `io.Writer` wrapper — that is set as the `EnvoyErrorStream` for the Envoy subprocess. It:

1. Forwards every `Write()` call transparently to the underlying writer (`os.Stderr`), so logging is unaffected.
2. Checks each write for the substring `"is too old and is not supported by Consul"` (version-number-agnostic).
3. On match: logs a clear `ERROR`-level message and calls `xdsServer.closeExitedCh()`, which feeds into the existing `doneCh`-based shutdown path — killing the Envoy subprocess and returning a non-zero exit code.

`closeExitedCh()` uses `sync.Once` to prevent double-close panics if multiple concurrent writes carry the same message.

### Files changed

| File | Change |
|------|--------|
| `pkg/consuldp/xds.go` | Added `envoyVersionUnsupportedMsg` constant; `newEnvoyLogScanner()` constructor; `envoyLogScanner` struct and `Write()` method; `xdsServer.closeExitedCh()` using `sync.Once` |
| `pkg/consuldp/consul_dataplane.go` | Added `closeOnce sync.Once` to `xdsServer` struct; `envoyProxyConfig()` sets `EnvoyErrorStream: cdp.newEnvoyLogScanner(os.Stderr)`; `startXDSServer` uses `closeExitedCh()` |
| `pkg/consuldp/xds_test.go` | `TestEnvoyLogScannerFatalExit` (table-driven, 4 cases); `TestEnvoyLogScannerCloseOnce` (concurrent double-write panic guard) |

## Testing

### Unit tests

```
go test ./pkg/... -run TestEnvoyLogScanner -v
```

All tests pass. Coverage:
- Exact rejection message → `exitedCh` closed ✅
- Different Envoy version number in message → `exitedCh` closed ✅  
- Unrelated log line → `exitedCh` stays open ✅
- Empty write → `exitedCh` stays open ✅
- 5 concurrent writes of fatal message → no panic (`sync.Once` guard) ✅

### Live cluster validation (KIND + Consul 2.0.0+ent)

Tested two images built with Envoy 1.33.4 (rejected by Consul ≥2.0):

| Image | Consul-dataplane binary | Result |
|-------|------------------------|--------|
| `stock` | upstream main | Pod stays `Running` indefinitely — **zombie** |
| `fixed` | this branch | Pod reaches `Error` state in **<5 seconds** |

Fixed binary log sequence on exit:
```
[ERROR] consul-dataplane: Envoy version is not supported by Consul server — this is a permanent error, consul-dataplane will now exit. Please upgrade Envoy to a supported version.
[INFO]  consul-dataplane: xds server exited. triggering quit
xDS server exited unexpectedly
```

## Changelog

```
bug fixes:
* Fixed consul-dataplane looping forever when Envoy version is rejected by Consul server as unsupported. consul-dataplane now exits immediately with a non-zero code and a clear error message, unblocking rolling deployments.
```