### PR TITLE
Update security-scanner workflow to inherit secrets to build WF

### DIFF
--- a/.github/workflows/scan-containers-binaries.yaml
+++ b/.github/workflows/scan-containers-binaries.yaml
@@ -60,6 +60,7 @@ jobs:
       # (for pre-merge testing). Pass the flag through so build.yml's
       # conditional-skip guard doesn't reject the run.
       allow-unprotected-branches: true
+    secrets: inherit
 
   # 2. Resolve the Go toolchain version the scanner uses for go_modules analysis.
   get-go-version:


### PR DESCRIPTION
Build part in the scan-containers-binaries workflow is failing with missing credentials error, added the secrets: inherit field so that credentials are passed to build wf.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
