### PR TITLE
fix vulnerability for user to root group addition

### DIFF
--- a/.changelog/1266.txt
+++ b/.changelog/1266.txt
@@ -1,0 +1,3 @@
+```release-note:security
+docker: Remove unnecessary `root` group membership for the `consul-dataplane` service user in the UBI-based release images (`release-ubi`, `release-fips-ubi`). The `usermod -a -G root` call granted the process read access to files with group-read permissions owned by `root`, violating the principle of least privilege. The user continues to run as UID 100 in its own dedicated group (GID 1000).
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,8 +183,7 @@ RUN microdnf update -y && \
 
 # Create a non-root user to run the software.
 RUN groupadd --gid 1000 $PRODUCT_NAME && \
-    adduser --uid 100 --system -g $PRODUCT_NAME $PRODUCT_NAME && \
-    usermod -a -G root $PRODUCT_NAME
+    adduser --uid 100 --system -g $PRODUCT_NAME $PRODUCT_NAME
 
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
 COPY --from=go-discover /go/bin/discover /usr/local/bin/
@@ -234,8 +233,7 @@ RUN microdnf update -y && \
 
 # Create a non-root user to run the software.
 RUN groupadd --gid 1000 $PRODUCT_NAME && \
-    adduser --uid 100 --system -g $PRODUCT_NAME $PRODUCT_NAME && \
-    usermod -a -G root $PRODUCT_NAME
+    adduser --uid 100 --system -g $PRODUCT_NAME $PRODUCT_NAME
 
 COPY --from=dumb-init /usr/bin/dumb-init /usr/local/bin/
 COPY --from=go-discover /go/bin/discover /usr/local/bin/


### PR DESCRIPTION
This PR context  : 
1) The UBI images are mostly the same runtime layout as the distroless images
The runtime payloads copied into the images are the same kinds of artifacts:

- dumb-init
- discover
- envoy
- consul-dataplane
- privileged-* variants for NET_BIND_SERVICE support
The UBI stages differ mainly in:
- using ubi9-minimal
- installing shadow-utils
- creating the non-root user
- the old root group membership
There is no sign of a UBI-specific runtime wrapper or entrypoint script.

2) The root group change appears to be a permission workaround, not an app requirement
It is mostly granted the process read access to files with group-read permissions owned by root and this violated least privilege.
That implies it was broad access to avoid permission edge cases, not because one specific runtime file truly needed it.

3) Likely runtime files do not need root group membership
The most likely runtime paths are:

-/usr/local/bin/dumb-init
-/usr/local/bin/discover
-/usr/local/bin/envoy
-/usr/local/bin/consul-dataplane
-/usr/share/doc/$PRODUCT_NAME/LICENSE.txt
These are all expected to be readable/executable by a normal service user. Nothing in the repository suggests they are group-restricted to root in a way that would require the added group membership.

4) No explicit UBI-only runtime code beyond the Dockerfile

-limited to Dockerfile UBI stages 
- No UBI-specific Go code
- No OpenShift-specific runtime logic
- No scripts that branch on UBI at runtime
- No config files that depend on the service user being in the root group


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, image user group permissions, etc.
  
  
  
