### PR TITLE
Pin docker/login-action to a commit hash

### DIFF
--- a/.changelog/1272.txt
+++ b/.changelog/1272.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Pin `docker/login-action` to a commit hash to fix high-severity code-scanning alerts for missing pinned commit hashes in GitHub Actions workflows.
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -265,7 +265,7 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -299,7 +299,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # This naming convention will be used ONLY for per-commit dev images
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/consul-dataplane-checks.yaml
+++ b/.github/workflows/consul-dataplane-checks.yaml
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes CodeQL code-scanning alerts (severity: high) flagging `docker/login-action@v3` as not pinned to a commit hash:
- https://github.com/hashicorp/consul-dataplane/security/code-scanning/51
- https://github.com/hashicorp/consul-dataplane/security/code-scanning/52
- https://github.com/hashicorp/consul-dataplane/security/code-scanning/53
- https://github.com/hashicorp/consul-dataplane/security/code-scanning/65

Pins `docker/login-action@v3` to the `v3.6.0` commit SHA (`5e57cd118135c172c3672efd75eb46360885c0ef`) in `build.yml` (3 occurrences) and `consul-dataplane-checks.yaml` (1 occurrence), matching the existing pinning pattern used for `actions/checkout` in the same workflows.

Note: All active release branches uses`hashicorp/actions-docker-build@v2` (which handles Docker Hub auth internally) instead of an explicit login step. The alerts (#51/#52/#53/#65) were correctly scoped to `main` only.

## Testing
Workflow-only change; no application code affected.