### PR TITLE
Prepare release 1.8.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.8.17 (September 9, 2026)
+SECURITY:
+
+* Upgrade `go-discover` build stage to use `golang.org/x/crypto` 0.57.0.
+This resolves [GO-2026-6354](https://pkg.go.dev/vuln/GO-2026-6354) (CVE-2026-78662) and [GO-2026-6355](https://pkg.go.dev/vuln/GO-2026-6355) (CVE-2026-56855)
+Upgrade `go-discover` build stage to use `golang.org/x/net` 0.59.0.
+Upgrade `golang.org/x/net` to 0.59.0. [[GH-1281](https://github.com/hashicorp/consul-dataplane/pull/1281)]
+* Upgrade `go-discover` build stage to use `google.golang.org/grpc` 1.83.2.
+This resolves [GHSA-vp52-pcj8-j9qc](https://github.com/advisories/GHSA-vp52-pcj8-j9qc)
+Upgrade `go-discover` build stage to use `golang.org/x/net` 0.58.0. [[GH-1276](https://github.com/hashicorp/consul-dataplane/pull/1276)]
+* Upgrade go version to 1.26.7 to address security vulnerabilities. [[GH-1262](https://github.com/hashicorp/consul-dataplane/pull/1262)]
+* Upgrade to use `google.golang.org/grpc` 1.83.2.
+This resolves [GHSA-vp52-pcj8-j9qc](https://github.com/advisories/GHSA-vp52-pcj8-j9qc) [[GH-1271](https://github.com/hashicorp/consul-dataplane/pull/1271)]
+* docker: Remove unnecessary `root` group membership for the `consul-dataplane` service user in the UBI-based release images (`release-ubi`, `release-fips-ubi`). The `usermod -a -G root` call granted the process read access to files with group-read permissions owned by `root`, violating the principle of least privilege. The user continues to run as UID 100 in its own dedicated group (GID 1000). [[GH-1266](https://github.com/hashicorp/consul-dataplane/pull/1266)]
+
+IMPROVEMENTS:
+
+* fips: migrate FIPS builds from FIPS 140-2 (BoringCrypto) to FIPS 140-3 using the in-tree Go Cryptographic Module (`GOFIPS140=v1.0.0`, CMVP certificate #5247). Version output now reports `+fips1403`. The bundled Envoy is bumped to 1.38.4, the first release with a published FIPS 140-3 image. [[GH-1196](https://github.com/hashicorp/consul-dataplane/pull/1196)]
+
 ## 1.8.16 (August 10, 2026)
 
 SECURITY:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ SECURITY:
 This resolves [GO-2026-6354](https://pkg.go.dev/vuln/GO-2026-6354) (CVE-2026-78662) and [GO-2026-6355](https://pkg.go.dev/vuln/GO-2026-6355) (CVE-2026-56855)
 Upgrade `go-discover` build stage to use `golang.org/x/net` 0.59.0.
 Upgrade `golang.org/x/net` to 0.59.0. [[GH-1281](https://github.com/hashicorp/consul-dataplane/pull/1281)]
+
 * Upgrade `go-discover` build stage to use `google.golang.org/grpc` 1.83.2.
 This resolves [GHSA-vp52-pcj8-j9qc](https://github.com/advisories/GHSA-vp52-pcj8-j9qc)
-Upgrade `go-discover` build stage to use `golang.org/x/net` 0.58.0. [[GH-1276](https://github.com/hashicorp/consul-dataplane/pull/1276)]
+
 * Upgrade go version to 1.26.7 to address security vulnerabilities. [[GH-1262](https://github.com/hashicorp/consul-dataplane/pull/1262)]
+
 * Upgrade to use `google.golang.org/grpc` 1.83.2.
 This resolves [GHSA-vp52-pcj8-j9qc](https://github.com/advisories/GHSA-vp52-pcj8-j9qc) [[GH-1271](https://github.com/hashicorp/consul-dataplane/pull/1271)]
+
 * docker: Remove unnecessary `root` group membership for the `consul-dataplane` service user in the UBI-based release images (`release-ubi`, `release-fips-ubi`). The `usermod -a -G root` call granted the process read access to files with group-read permissions owned by `root`, violating the principle of least privilege. The user continues to run as UID 100 in its own dedicated group (GID 1000). [[GH-1266](https://github.com/hashicorp/consul-dataplane/pull/1266)]
 
 IMPROVEMENTS:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,12 +17,12 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.8.0"
+	Version = "1.8.17"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
Automated release preparation for consul-dataplane 1.8.17.

Generated by `release-scripts/prepare-release-branch.sh`:
- Bumped `pkg/version/version.go` to 1.8.17 (`make prepare-release`).
- Prepended the 1.8.17 CHANGELOG entry (`make changelog`, since v1.8.16).

Base branch `release/1.8.17` was cut from `release/1.8.x`.