### PR TITLE
Changelog entry to release/1.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.9.12 (September 9, 2026)
+
+SECURITY:
+
+* Upgrade `go-discover` build stage to use `golang.org/x/crypto` 0.57.0.
+This resolves [GO-2026-6354](https://pkg.go.dev/vuln/GO-2026-6354) (CVE-2026-78662) and [GO-2026-6355](https://pkg.go.dev/vuln/GO-2026-6355) (CVE-2026-56855)
+Upgrade `go-discover` build stage to use `golang.org/x/net` 0.59.0.
+Upgrade `golang.org/x/net` to 0.59.0. [[GH-1281](https://github.com/hashicorp/consul-dataplane/pull/1281)]
+
+* Upgrade `go-discover` build stage to use `google.golang.org/grpc` 1.83.2.
+This resolves [GHSA-vp52-pcj8-j9qc](https://github.com/advisories/GHSA-vp52-pcj8-j9qc)
+
+* Upgrade go version to 1.26.7 to address security vulnerabilities. [[GH-1262](https://github.com/hashicorp/consul-dataplane/pull/1262)]
+
+* Upgrade to use `google.golang.org/grpc` 1.83.2.
+This resolves [GHSA-vp52-pcj8-j9qc](https://github.com/advisories/GHSA-vp52-pcj8-j9qc) [[GH-1271](https://github.com/hashicorp/consul-dataplane/pull/1271)]
+
+* docker: Remove unnecessary `root` group membership for the `consul-dataplane` service user in the UBI-based release images (`release-ubi`, `release-fips-ubi`). The `usermod -a -G root` call granted the process read access to files with group-read permissions owned by `root`, violating the principle of least privilege. The user continues to run as UID 100 in its own dedicated group (GID 1000). [[GH-1266](https://github.com/hashicorp/consul-dataplane/pull/1266)]
+
+IMPROVEMENTS:
+
+* fips: migrate FIPS builds from FIPS 140-2 (BoringCrypto) to FIPS 140-3 using the in-tree Go Cryptographic Module (`GOFIPS140=v1.0.0`, CMVP certificate #5247). Version output now reports `+fips1403`. The bundled Envoy is bumped to 1.38.4, the first release with a published FIPS 140-3 image. [[GH-1196](https://github.com/hashicorp/consul-dataplane/pull/1196)]
+
 ## 1.9.11 (August 10, 2026)
 
 SECURITY:


### PR DESCRIPTION
Post-release step: add the CHANGELOG entry for 1.9.12 (released Sept 9, 2026) to the long-lived `release/1.9.x` branch.

Dependency bumps for this release (`x/net` 0.59.0, `x/crypto` 0.57.0, `grpc` 1.83.2) are already present on this branch via prior backport PRs, so no further dependency changes are needed here.